### PR TITLE
site: update Ingress versions

### DIFF
--- a/.helm/templates/20-ingress-tuf-router.yaml
+++ b/.helm/templates/20-ingress-tuf-router.yaml
@@ -3,7 +3,7 @@
 {{- $host = ( printf "%s.%s" .Values.werf.env (pluck "dev" .Values.host | first | default .Values.host._default ) | lower ) }}
 {{- end }}
 
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: tuf-router
@@ -20,21 +20,33 @@ spec:
     http:
       paths:
       - path: /targets
+        pathType: Prefix
         backend:
-          serviceName: tuf-router
-          servicePort: http
+          service:
+            name: tuf-router
+            port:
+              name: http
       - path: /download
+        pathType: Prefix
         backend:
-          serviceName: tuf-router
-          servicePort: http
+          service:
+            name: tuf-router
+            port:
+              name: http
   - host: ru.{{ $host }}
     http:
       paths:
       - path: /targets
+        pathType: Prefix
         backend:
-          serviceName: tuf-router
-          servicePort: http
+          service:
+            name: tuf-router
+            port:
+              name: http
       - path: /download
+        pathType: Prefix
         backend:
-          serviceName: tuf-router
-          servicePort: http
+          service:
+            name: tuf-router
+            port:
+              name: http

--- a/.helm/templates/20-ingress.yaml
+++ b/.helm/templates/20-ingress.yaml
@@ -3,7 +3,7 @@
 {{- $host = ( printf "%s.%s" .Values.werf.env (pluck "dev" .Values.host | first | default .Values.host._default ) | lower ) }}
 {{- end }}
 
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: main
@@ -33,16 +33,22 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: backend
-          servicePort: http
+          service:
+            name: backend
+            port:
+              name: http
   - host: ru.{{ $host }}
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: backend
-          servicePort: http
+          service:
+            name: backend
+            port:
+              name: http
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate


### PR DESCRIPTION
Update Ingress resources API version to get rid of using deprecated CRD APIs on the site.