### PR TITLE
site: pin jekyll image version

### DIFF
--- a/.github/workflows/content_validation.yml
+++ b/.github/workflows/content_validation.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   check_links:
-    container: jekyll/builder:4
+    container: jekyll/builder:4.2.0
     name: Check broken links
     runs-on: ubuntu-latest
     strategy:

--- a/werf.yaml
+++ b/werf.yaml
@@ -4,7 +4,7 @@ project: werf-site
 
 image: jekyll_base
 fromCacheVersion: "1"
-from: jekyll/builder:4
+from: jekyll/builder:4.2.0
 git:
   - add: /
     to: /app


### PR DESCRIPTION
Pin the [jekyll/builder](https://hub.docker.com/r/jekyll/builder) image to the version 4.2.0. The reason is that the next tag — 4.2.2 uses ruby 3 (3.1.1) instead of ruby 2 (2.7.1) in 4.2.0. Some gems are not working with ruby 3.