### PR TITLE
ci: use the trdl_channels.yaml file from the main branch

### DIFF
--- a/.werf/artifacts/get_git_history.sh
+++ b/.werf/artifacts/get_git_history.sh
@@ -16,7 +16,7 @@ _PWD=$PWD
 
 WORKDIR=$(mktemp -d -p /tmp/)
 REPO=${1:-https://github.com/werf/werf.git}
-BRANCH=${2:-multiwerf}
+BRANCH=${2:-main}
 
 if [[ -x /usr/local/bin/yq ]]; then
   YQ=/usr/local/bin/yq


### PR DESCRIPTION
Use the trdl_channels.yaml file from the main branch instead of the multiwerf branch.