### PR TITLE
fix: Jekyll.configuration() is an expensive call

### DIFF
--- a/_plugins/filesused.rb
+++ b/_plugins/filesused.rb
@@ -32,8 +32,8 @@ module Jekyll
 
       def render(context)
         content = super
-
-        rendered_content = Jekyll::Converters::Markdown::KramdownParser.new(Jekyll.configuration()).convert(content)
+        site_config = context.registers[:site].config
+        rendered_content = Jekyll::Converters::Markdown::KramdownParser.new(site_config).convert(content)
 
         %Q(
 <div class="filesused">

--- a/_plugins/offtopic.rb
+++ b/_plugins/offtopic.rb
@@ -33,7 +33,8 @@ module Jekyll
       def render(context)
         content = super
 
-        rendered_content = Jekyll::Converters::Markdown::KramdownParser.new(Jekyll.configuration()).convert(content)
+        site_config = context.registers[:site].config
+        rendered_content = Jekyll::Converters::Markdown::KramdownParser.new(site_config).convert(content)
 
         if @config[:compact]
           div_details_class = "details details__compact"

--- a/_plugins/snippetcut.rb
+++ b/_plugins/snippetcut.rb
@@ -23,7 +23,7 @@ module Jekyll
         @markup = Liquid::Template
           .parse(@raw_markup)
           .render(context)
-          .gsub(%r!\\\{\\\{|\\\{\\%!, '\{\{' => "{{", '\{\%' => "{%")
+          .gsub(/\\[{]\\[{%]/, '\{\{' => "{{", '\{\%' => "{%")
           .strip
 
         override_config(@@DEFAULTS)
@@ -38,7 +38,8 @@ module Jekyll
         end
 
         content = super
-        rendered_content = Jekyll::Converters::Markdown::KramdownParser.new(Jekyll.configuration()).convert(content)
+        site_config = context.registers[:site].config
+        rendered_content = Jekyll::Converters::Markdown::KramdownParser.new(site_config).convert(content)
 
         %Q(
 <div class="snippetcut#{@config[:limited] ? ' snippetcut_limited' : ''}" data-snippetcut>


### PR DESCRIPTION
- Use context.registers to prevent parsing config file.
- Jekyll.configuration() is not correct when multiple files are used.
- Source: https://github.com/jekyll/jekyll/issues/1578#issuecomment-25109633
- TODO: update plantuml plugin after merging https://github.com/flant/jekyll_remote_plantuml_plugin/pull/8