### PR TITLE
fix: always show sidebar in codesandbox ide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ backend/root/
 .bundle
 vendor/
 bin/configurator/generated/
+/_includes/*/configurator
+/pages_*/configurator*
+/_data/*/configurator*

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -112,3 +112,29 @@ tasks:
       # NOTE: also we need werf itself
       - sudo apt install pv asciinema
       - wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
+
+  clean:
+    desc: "Delete temporary directories after build/serve"
+    cmds:
+      - |
+        for d in $(ls -1d ./_site* ./.jekyll-cache* ./.jekyll-metadata 2>/dev/null) ; do
+          echo "Remove dir $d ..."
+          rm -rf $d
+        done
+        echo "Remove configurator generated content"
+        for d in $(ls -1d ./_includes/*/configurator ./pages_*/configurator* ./_data/*/configurator* 2>/dev/null) ; do
+          echo "   Remove dir $d ..."
+          rm -rf $d
+        done
+
+  local:gen:configurator:
+    desc: "Regenerate configurator pages and copy to site directories"
+    cmds:
+      - |
+        (
+          echo Regenerate configurator pages...
+          cd bin/configurator
+          go run *.go
+        )
+        cp -R bin/configurator/static/* .
+        cp -R bin/configurator/generated/* .

--- a/assets/css/configurator.css
+++ b/assets/css/configurator.css
@@ -135,3 +135,31 @@
     opacity: .2;
     margin-left: 7px;
 }
+
+/* Super trick:
+- Set iframe width to minimal width when codesandbox shows a sidebar
+https://github.com/codesandbox/codesandbox-client/blob/389073613e06eee944231f4aeef9dfa746c1b947/packages/app/src/embed/util/constants.js
+https://github.com/codesandbox/codesandbox-client/blob/389073613e06eee944231f4aeef9dfa746c1b947/packages/app/src/embed/components/App/index.js#L99
+- Use wrapper to show iframe inside narrower column
+- Move iframe off the screen for lazy loading.
+*/
+.codesandbox__wrap {
+    width: 100%;
+    overflow: auto;
+    border-radius: 4px;
+    border: 0;
+    line-height: 0;
+}
+
+.codesandbox__wrap iframe {
+    width: 1281px !important;
+    height: 500px;
+    border: 0;
+    border-radius: 4px;
+    overflow:hidden;
+}
+
+.view__item:not(.active) .codesandbox__wrap iframe {
+    position: absolute;
+    left: -5000px;
+}

--- a/bin/configurator/static/_includes/_common/configurator/codesandbox.html
+++ b/bin/configurator/static/_includes/_common/configurator/codesandbox.html
@@ -1,0 +1,6 @@
+<div class="codesandbox__wrap">
+<iframe
+  src="https://codesandbox.io/embed/{{include.github_path}}?module={{include.module}}&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1"
+  loading="lazy"
+  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+</div>

--- a/bin/configurator/static/_includes/en/configurator/tab/ci/github-actions/simple/host-runner/linux/buildah/project.md.liquid
+++ b/bin/configurator/static/_includes/en/configurator/tab/ci/github-actions/simple/host-runner/linux/buildah/project.md.liquid
@@ -12,7 +12,7 @@ Save the kubeconfig file to access the Kubernetes cluster as a `KUBECONFIG_BASE6
 
 This is how the repository that uses werf for build and deploy might look:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/ci-cd/simple/github-actions/host-runner/linux/buildah?module=/.github/workflows/prod.yml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/ci-cd/simple/github-actions/host-runner/linux/buildah' module='/.github/workflows/prod.yml' %}
 
 Extras:
   * Add authorization options for `werf cleanup` in the container registry by following [instructions]({{ "/documentation/v1.2/usage/cleanup/cr_cleanup.html#features-of-working-with-different-container-registries" | relative_url }}).

--- a/bin/configurator/static/_includes/en/configurator/tab/ci/gitlab-ci-cd/best-practice/with-per-repo-ci-cd/application/docker-runner/linux/buildah/project.md.liquid
+++ b/bin/configurator/static/_includes/en/configurator/tab/ci/gitlab-ci-cd/best-practice/with-per-repo-ci-cd/application/docker-runner/linux/buildah/project.md.liquid
@@ -36,7 +36,7 @@
 
 This is how the repository that uses werf for build and deploy might look:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/ci-cd/best-practice/with-per-repo-ci-cd/gitlab-ci-cd/app-repo/docker-runner/linux/buildah?module=/.gitlab-ci.yml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/ci-cd/best-practice/with-per-repo-ci-cd/gitlab-ci-cd/app-repo/docker-runner/linux/buildah' module='/.gitlab-ci.yml' %}
 
 Extras:
   * Add authorization options for `werf cleanup` in the container registry by following [instructions]({{ "/documentation/v1.2/usage/cleanup/cr_cleanup.html#features-of-working-with-different-container-registries" | relative_url }}).

--- a/bin/configurator/static/_includes/en/configurator/tab/ci/gitlab-ci-cd/best-practice/with-per-repo-ci-cd/application/host-runner/linux/buildah/project.md.liquid
+++ b/bin/configurator/static/_includes/en/configurator/tab/ci/gitlab-ci-cd/best-practice/with-per-repo-ci-cd/application/host-runner/linux/buildah/project.md.liquid
@@ -36,7 +36,7 @@
 
 This is how the repository that uses werf for build and deploy might look:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/ci-cd/best-practice/with-per-repo-ci-cd/gitlab-ci-cd/app-repo/host-runner/linux/buildah?module=/.gitlab-ci.yml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/ci-cd/best-practice/with-per-repo-ci-cd/gitlab-ci-cd/app-repo/host-runner/linux/buildah' module='/.gitlab-ci.yml' %}
 
 Extras:
   * Add authorization options for `werf cleanup` in the container registry by following [instructions]({{ "/documentation/v1.2/usage/cleanup/cr_cleanup.html#features-of-working-with-different-container-registries" | relative_url }}).

--- a/bin/configurator/static/_includes/en/configurator/tab/ci/gitlab-ci-cd/best-practice/with-per-repo-ci-cd/application/host-runner/linux/docker/project.md.liquid
+++ b/bin/configurator/static/_includes/en/configurator/tab/ci/gitlab-ci-cd/best-practice/with-per-repo-ci-cd/application/host-runner/linux/docker/project.md.liquid
@@ -36,7 +36,7 @@
 
 This is how the repository that uses werf for build and deploy might look:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/ci-cd/best-practice/with-per-repo-ci-cd/gitlab-ci-cd/app-repo/host-runner/linux/docker?module=/.gitlab-ci.yml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/ci-cd/best-practice/with-per-repo-ci-cd/gitlab-ci-cd/app-repo/host-runner/linux/docker' module='/.gitlab-ci.yml' %}
 
 Extras:
   * Add authorization options for `werf cleanup` in the container registry by following [instructions]({{ "/documentation/v1.2/usage/cleanup/cr_cleanup.html#features-of-working-with-different-container-registries" | relative_url }}).

--- a/bin/configurator/static/_includes/en/configurator/tab/ci/gitlab-ci-cd/best-practice/with-per-repo-ci-cd/application/kubernetes-runner/linux/buildah/project.md.liquid
+++ b/bin/configurator/static/_includes/en/configurator/tab/ci/gitlab-ci-cd/best-practice/with-per-repo-ci-cd/application/kubernetes-runner/linux/buildah/project.md.liquid
@@ -36,7 +36,7 @@
 
 This is how the repository that uses werf for build and deploy might look:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/ci-cd/best-practice/with-per-repo-ci-cd/gitlab-ci-cd/app-repo/kubernetes-runner/linux/buildah?module=/.gitlab-ci.yml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/ci-cd/best-practice/with-per-repo-ci-cd/gitlab-ci-cd/app-repo/kubernetes-runner/linux/buildah' module='/.gitlab-ci.yml' %}
 
 Extras:
   * Add authorization options for `werf cleanup` in the container registry by following [instructions]({{ "/documentation/v1.2/usage/cleanup/cr_cleanup.html#features-of-working-with-different-container-registries" | relative_url }}).

--- a/bin/configurator/static/_includes/en/configurator/tab/ci/gitlab-ci-cd/best-practice/with-per-repo-ci-cd/monorepo/docker-runner/linux/buildah/project.md.liquid
+++ b/bin/configurator/static/_includes/en/configurator/tab/ci/gitlab-ci-cd/best-practice/with-per-repo-ci-cd/monorepo/docker-runner/linux/buildah/project.md.liquid
@@ -36,7 +36,7 @@
 
 This is how the repository that uses werf for build and deploy might look:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/ci-cd/best-practice/with-per-repo-ci-cd/gitlab-ci-cd/monorepo/docker-runner/linux/buildah?module=/.gitlab-ci.yml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/ci-cd/best-practice/with-per-repo-ci-cd/gitlab-ci-cd/monorepo/docker-runner/linux/buildah' module='/.gitlab-ci.yml' %}
 
 Extras:
   * Add authorization options for `werf cleanup` in the container registry by following [instructions]({{ "/documentation/v1.2/usage/cleanup/cr_cleanup.html#features-of-working-with-different-container-registries" | relative_url }}).

--- a/bin/configurator/static/_includes/en/configurator/tab/ci/gitlab-ci-cd/best-practice/with-per-repo-ci-cd/monorepo/host-runner/linux/buildah/project.md.liquid
+++ b/bin/configurator/static/_includes/en/configurator/tab/ci/gitlab-ci-cd/best-practice/with-per-repo-ci-cd/monorepo/host-runner/linux/buildah/project.md.liquid
@@ -36,7 +36,7 @@
 
 This is how the repository that uses werf for build and deploy might look:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/ci-cd/best-practice/with-per-repo-ci-cd/gitlab-ci-cd/monorepo/host-runner/linux/buildah?module=/.gitlab-ci.yml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/ci-cd/best-practice/with-per-repo-ci-cd/gitlab-ci-cd/monorepo/host-runner/linux/buildah' module='/.gitlab-ci.yml' %}
 
 Extras:
   * Add authorization options for `werf cleanup` in the container registry by following [instructions]({{ "/documentation/v1.2/usage/cleanup/cr_cleanup.html#features-of-working-with-different-container-registries" | relative_url }}).

--- a/bin/configurator/static/_includes/en/configurator/tab/ci/gitlab-ci-cd/best-practice/with-per-repo-ci-cd/monorepo/host-runner/linux/docker/project.md.liquid
+++ b/bin/configurator/static/_includes/en/configurator/tab/ci/gitlab-ci-cd/best-practice/with-per-repo-ci-cd/monorepo/host-runner/linux/docker/project.md.liquid
@@ -36,7 +36,7 @@
 
 This is how the repository that uses werf for build and deploy might look:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/ci-cd/best-practice/with-per-repo-ci-cd/gitlab-ci-cd/monorepo/host-runner/linux/docker?module=/.gitlab-ci.yml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/ci-cd/best-practice/with-per-repo-ci-cd/gitlab-ci-cd/monorepo/host-runner/linux/docker' module='/.gitlab-ci.yml' %}
 
 Extras:
   * Add authorization options for `werf cleanup` in the container registry by following [instructions]({{ "/documentation/v1.2/usage/cleanup/cr_cleanup.html#features-of-working-with-different-container-registries" | relative_url }}).

--- a/bin/configurator/static/_includes/en/configurator/tab/ci/gitlab-ci-cd/best-practice/with-per-repo-ci-cd/monorepo/kubernetes-runner/linux/buildah/project.md.liquid
+++ b/bin/configurator/static/_includes/en/configurator/tab/ci/gitlab-ci-cd/best-practice/with-per-repo-ci-cd/monorepo/kubernetes-runner/linux/buildah/project.md.liquid
@@ -36,7 +36,7 @@
 
 This is how the repository that uses werf for build and deploy might look:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/ci-cd/best-practice/with-per-repo-ci-cd/gitlab-ci-cd/monorepo/kubernetes-runner/linux/buildah?module=/.gitlab-ci.yml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/ci-cd/best-practice/with-per-repo-ci-cd/gitlab-ci-cd/monorepo/kubernetes-runner/linux/buildah' module='/.gitlab-ci.yml' %}
 
 Extras:
   * Add authorization options for `werf cleanup` in the container registry by following [instructions]({{ "/documentation/v1.2/usage/cleanup/cr_cleanup.html#features-of-working-with-different-container-registries" | relative_url }}).

--- a/bin/configurator/static/_includes/en/configurator/tab/ci/gitlab-ci-cd/simple/docker-runner/linux/buildah/project.md.liquid
+++ b/bin/configurator/static/_includes/en/configurator/tab/ci/gitlab-ci-cd/simple/docker-runner/linux/buildah/project.md.liquid
@@ -26,7 +26,7 @@
 
 This is how the repository that uses werf for build and deploy might look:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/ci-cd/simple/gitlab-ci-cd/docker-runner/linux/buildah?module=/.gitlab-ci.yml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/ci-cd/simple/gitlab-ci-cd/docker-runner/linux/buildah' module='/.gitlab-ci.yml' %}
 
 Extras:
   * Add authorization options for `werf cleanup` in the container registry by following [instructions]({{ "/documentation/v1.2/usage/cleanup/cr_cleanup.html#features-of-working-with-different-container-registries" | relative_url }}).

--- a/bin/configurator/static/_includes/en/configurator/tab/ci/gitlab-ci-cd/simple/host-runner/linux/buildah/project.md.liquid
+++ b/bin/configurator/static/_includes/en/configurator/tab/ci/gitlab-ci-cd/simple/host-runner/linux/buildah/project.md.liquid
@@ -26,7 +26,7 @@
 
 This is how the repository that uses werf for build and deploy might look:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/ci-cd/simple/gitlab-ci-cd/host-runner/linux/buildah?module=/.gitlab-ci.yml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/ci-cd/simple/gitlab-ci-cd/host-runner/linux/buildah' module='/.gitlab-ci.yml' %}
 
 Extras:
   * Add authorization options for `werf cleanup` in the container registry by following [instructions]({{ "/documentation/v1.2/usage/cleanup/cr_cleanup.html#features-of-working-with-different-container-registries" | relative_url }}).

--- a/bin/configurator/static/_includes/en/configurator/tab/ci/gitlab-ci-cd/simple/host-runner/linux/docker/project.md.liquid
+++ b/bin/configurator/static/_includes/en/configurator/tab/ci/gitlab-ci-cd/simple/host-runner/linux/docker/project.md.liquid
@@ -26,7 +26,7 @@
 
 This is how the repository that uses werf for build and deploy might look:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/ci-cd/simple/gitlab-ci-cd/host-runner/linux/docker?module=/.gitlab-ci.yml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/ci-cd/simple/gitlab-ci-cd/host-runner/linux/docker' module='/.gitlab-ci.yml' %}
 
 Extras:
   * Add authorization options for `werf cleanup` in the container registry by following [instructions]({{ "/documentation/v1.2/usage/cleanup/cr_cleanup.html#features-of-working-with-different-container-registries" | relative_url }}).

--- a/bin/configurator/static/_includes/en/configurator/tab/ci/gitlab-ci-cd/simple/kubernetes-runner/linux/buildah/project.md.liquid
+++ b/bin/configurator/static/_includes/en/configurator/tab/ci/gitlab-ci-cd/simple/kubernetes-runner/linux/buildah/project.md.liquid
@@ -26,7 +26,7 @@
 
 This is how the repository that uses werf for build and deploy might look:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/ci-cd/simple/gitlab-ci-cd/kubernetes-runner/linux/buildah?module=/.gitlab-ci.yml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/ci-cd/simple/gitlab-ci-cd/kubernetes-runner/linux/buildah' module='/.gitlab-ci.yml' %}
 
 Extras:
   * Add authorization options for `werf cleanup` in the container registry by following [instructions]({{ "/documentation/v1.2/usage/cleanup/cr_cleanup.html#features-of-working-with-different-container-registries" | relative_url }}).

--- a/bin/configurator/static/_includes/en/configurator/tab/ci/other-ci-cd-system/simple/docker-runner/linux/buildah/project.md.liquid
+++ b/bin/configurator/static/_includes/en/configurator/tab/ci/other-ci-cd-system/simple/docker-runner/linux/buildah/project.md.liquid
@@ -2,7 +2,7 @@
 
 This is how the repository that uses werf for build and deploy might look:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/ci-cd/simple/other/docker-runner/linux/buildah?module=/pseudo-ci-cd-config.yaml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/ci-cd/simple/other/docker-runner/linux/buildah' module='/pseudo-ci-cd-config.yaml' %}
 
 Extras:
   * Add authorization options for `werf cleanup` in the container registry by following [instructions]({{ "/documentation/v1.2/usage/cleanup/cr_cleanup.html#features-of-working-with-different-container-registries" | relative_url }}).

--- a/bin/configurator/static/_includes/en/configurator/tab/ci/other-ci-cd-system/simple/host-runner/linux/buildah/project.md.liquid
+++ b/bin/configurator/static/_includes/en/configurator/tab/ci/other-ci-cd-system/simple/host-runner/linux/buildah/project.md.liquid
@@ -2,7 +2,7 @@
 
 This is how the repository that uses werf for build and deploy might look:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/ci-cd/simple/other/host-runner/linux/buildah?module=/pseudo-ci-cd-config.yaml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/ci-cd/simple/other/host-runner/linux/buildah' module='/pseudo-ci-cd-config.yaml' %}
 
 Extras:
   * Add authorization options for `werf cleanup` in the container registry by following [instructions]({{ "/documentation/v1.2/usage/cleanup/cr_cleanup.html#features-of-working-with-different-container-registries" | relative_url }}).

--- a/bin/configurator/static/_includes/en/configurator/tab/ci/other-ci-cd-system/simple/host-runner/linux/docker/project.md.liquid
+++ b/bin/configurator/static/_includes/en/configurator/tab/ci/other-ci-cd-system/simple/host-runner/linux/docker/project.md.liquid
@@ -2,7 +2,7 @@
 
 This is how the repository that uses werf for build and deploy might look:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/ci-cd/simple/other/docker-runner/linux/docker?module=/pseudo-ci-cd-config.yaml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/ci-cd/simple/other/docker-runner/linux/docker' module='/pseudo-ci-cd-config.yaml' %}
 
 Extras:
   * Add authorization options for `werf cleanup` in the container registry by following [instructions]({{ "/documentation/v1.2/usage/cleanup/cr_cleanup.html#features-of-working-with-different-container-registries" | relative_url }}).

--- a/bin/configurator/static/_includes/en/configurator/tab/ci/other-ci-cd-system/simple/kubernetes-runner/linux/buildah/project.md.liquid
+++ b/bin/configurator/static/_includes/en/configurator/tab/ci/other-ci-cd-system/simple/kubernetes-runner/linux/buildah/project.md.liquid
@@ -2,7 +2,7 @@
 
 This is how the repository that uses werf for build and deploy might look:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/ci-cd/simple/other/kubernetes-runner/linux/buildah?module=/pseudo-ci-cd-config.yaml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/ci-cd/simple/other/kubernetes-runner/linux/buildah' module='/pseudo-ci-cd-config.yaml' %}
 
 Extras:
   * Add authorization options for `werf cleanup` in the container registry by following [instructions]({{ "/documentation/v1.2/usage/cleanup/cr_cleanup.html#features-of-working-with-different-container-registries" | relative_url }}).

--- a/bin/configurator/static/_includes/en/configurator/tab/dev/linux/buildah/run.md.liquid
+++ b/bin/configurator/static/_includes/en/configurator/tab/dev/linux/buildah/run.md.liquid
@@ -10,7 +10,7 @@
 
 Contents of the demo project:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/local-dev?module=/werf.yaml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/local-dev' module='/werf.yaml' %}
 
 Initialize the demo project on the local machine:
 

--- a/bin/configurator/static/_includes/en/configurator/tab/dev/linux/docker/run.md.liquid
+++ b/bin/configurator/static/_includes/en/configurator/tab/dev/linux/docker/run.md.liquid
@@ -10,7 +10,7 @@
 
 Contents of the demo project:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/local-dev?module=/werf.yaml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/local-dev' module='/werf.yaml' %}
 
 Initialize the demo project on the local machine:
 

--- a/bin/configurator/static/_includes/en/configurator/tab/dev/macos/docker/run.md.liquid
+++ b/bin/configurator/static/_includes/en/configurator/tab/dev/macos/docker/run.md.liquid
@@ -10,7 +10,7 @@
 
 Contents of the demo project:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/local-dev?module=/werf.yaml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/local-dev' module='/werf.yaml' %}
 
 Initialize the demo project on the local machine:
 

--- a/bin/configurator/static/_includes/en/configurator/tab/dev/windows/docker/run.md.liquid
+++ b/bin/configurator/static/_includes/en/configurator/tab/dev/windows/docker/run.md.liquid
@@ -10,7 +10,7 @@
 
 Contents of the demo project:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/local-dev?module=/werf.yaml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/local-dev' module='/werf.yaml' %}
 
 Initialize the demo project on the local machine:
 

--- a/bin/configurator/static/_includes/ru/configurator/tab/ci/github-actions/simple/host-runner/linux/buildah/project.md.liquid
+++ b/bin/configurator/static/_includes/ru/configurator/tab/ci/github-actions/simple/host-runner/linux/buildah/project.md.liquid
@@ -12,7 +12,7 @@
 
 Так может выглядеть репозиторий, использующий werf для сборки и развертывания:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/ci-cd/simple/github-actions/host-runner/linux/buildah?module=/.github/workflows/prod.yml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/ci-cd/simple/github-actions/host-runner/linux/buildah' module='/.github/workflows/prod.yml' %}
 
 {% capture registry_guide_url %}/documentation/v1.2/usage/cleanup/cr_cleanup.html#%D0%BE%D1%81%D0%BE%D0%B1%D0%B5%D0%BD%D0%BD%D0%BE%D1%81%D1%82%D0%B8-%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D1%8B-%D1%81-%D1%80%D0%B0%D0%B7%D0%BB%D0%B8%D1%87%D0%BD%D1%8B%D0%BC%D0%B8-container-registries{% endcapture %}
 Дополнительно:

--- a/bin/configurator/static/_includes/ru/configurator/tab/ci/gitlab-ci-cd/best-practice/with-per-repo-ci-cd/application/docker-runner/linux/buildah/project.md.liquid
+++ b/bin/configurator/static/_includes/ru/configurator/tab/ci/gitlab-ci-cd/best-practice/with-per-repo-ci-cd/application/docker-runner/linux/buildah/project.md.liquid
@@ -36,7 +36,7 @@
 
 Так может выглядеть репозиторий, использующий werf для сборки и развертывания:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/ci-cd/best-practice/with-per-repo-ci-cd/gitlab-ci-cd/app-repo/docker-runner/linux/buildah?module=/.gitlab-ci.yml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/ci-cd/best-practice/with-per-repo-ci-cd/gitlab-ci-cd/app-repo/docker-runner/linux/buildah' module='/.gitlab-ci.yml' %}
 
 {% capture registry_guide_url %}/documentation/v1.2/usage/cleanup/cr_cleanup.html#%D0%BE%D1%81%D0%BE%D0%B1%D0%B5%D0%BD%D0%BD%D0%BE%D1%81%D1%82%D0%B8-%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D1%8B-%D1%81-%D1%80%D0%B0%D0%B7%D0%BB%D0%B8%D1%87%D0%BD%D1%8B%D0%BC%D0%B8-container-registries{% endcapture %}
 Дополнительно:

--- a/bin/configurator/static/_includes/ru/configurator/tab/ci/gitlab-ci-cd/best-practice/with-per-repo-ci-cd/application/host-runner/linux/buildah/project.md.liquid
+++ b/bin/configurator/static/_includes/ru/configurator/tab/ci/gitlab-ci-cd/best-practice/with-per-repo-ci-cd/application/host-runner/linux/buildah/project.md.liquid
@@ -40,7 +40,7 @@
 
 Так может выглядеть репозиторий, использующий werf для сборки и развертывания:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/ci-cd/best-practice/with-per-repo-ci-cd/gitlab-ci-cd/app-repo/host-runner/linux/buildah?module=/.gitlab-ci.yml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/ci-cd/best-practice/with-per-repo-ci-cd/gitlab-ci-cd/app-repo/host-runner/linux/buildah' module='/.gitlab-ci.yml' %}
 
 {% capture registry_guide_url %}/documentation/v1.2/usage/cleanup/cr_cleanup.html#%D0%BE%D1%81%D0%BE%D0%B1%D0%B5%D0%BD%D0%BD%D0%BE%D1%81%D1%82%D0%B8-%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D1%8B-%D1%81-%D1%80%D0%B0%D0%B7%D0%BB%D0%B8%D1%87%D0%BD%D1%8B%D0%BC%D0%B8-container-registries{% endcapture %}
 Дополнительно:

--- a/bin/configurator/static/_includes/ru/configurator/tab/ci/gitlab-ci-cd/best-practice/with-per-repo-ci-cd/application/host-runner/linux/docker/project.md.liquid
+++ b/bin/configurator/static/_includes/ru/configurator/tab/ci/gitlab-ci-cd/best-practice/with-per-repo-ci-cd/application/host-runner/linux/docker/project.md.liquid
@@ -36,7 +36,7 @@
 
 Так может выглядеть репозиторий, использующий werf для сборки и развертывания:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/ci-cd/best-practice/with-per-repo-ci-cd/gitlab-ci-cd/app-repo/host-runner/linux/docker?module=/.gitlab-ci.yml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/ci-cd/best-practice/with-per-repo-ci-cd/gitlab-ci-cd/app-repo/host-runner/linux/docker' module='/.gitlab-ci.yml' %}
 
 {% capture registry_guide_url %}/documentation/v1.2/usage/cleanup/cr_cleanup.html#%D0%BE%D1%81%D0%BE%D0%B1%D0%B5%D0%BD%D0%BD%D0%BE%D1%81%D1%82%D0%B8-%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D1%8B-%D1%81-%D1%80%D0%B0%D0%B7%D0%BB%D0%B8%D1%87%D0%BD%D1%8B%D0%BC%D0%B8-container-registries{% endcapture %}
 Дополнительно:

--- a/bin/configurator/static/_includes/ru/configurator/tab/ci/gitlab-ci-cd/best-practice/with-per-repo-ci-cd/application/kubernetes-runner/linux/buildah/project.md.liquid
+++ b/bin/configurator/static/_includes/ru/configurator/tab/ci/gitlab-ci-cd/best-practice/with-per-repo-ci-cd/application/kubernetes-runner/linux/buildah/project.md.liquid
@@ -36,7 +36,7 @@
 
 Так может выглядеть репозиторий, использующий werf для сборки и развертывания:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/ci-cd/best-practice/with-per-repo-ci-cd/gitlab-ci-cd/app-repo/kubernetes-runner/linux/buildah?module=/.gitlab-ci.yml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/ci-cd/best-practice/with-per-repo-ci-cd/gitlab-ci-cd/app-repo/kubernetes-runner/linux/buildah' module='/.gitlab-ci.yml' %}
 
 {% capture registry_guide_url %}/documentation/v1.2/usage/cleanup/cr_cleanup.html#%D0%BE%D1%81%D0%BE%D0%B1%D0%B5%D0%BD%D0%BD%D0%BE%D1%81%D1%82%D0%B8-%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D1%8B-%D1%81-%D1%80%D0%B0%D0%B7%D0%BB%D0%B8%D1%87%D0%BD%D1%8B%D0%BC%D0%B8-container-registries{% endcapture %}
 Дополнительно:

--- a/bin/configurator/static/_includes/ru/configurator/tab/ci/gitlab-ci-cd/best-practice/with-per-repo-ci-cd/monorepo/docker-runner/linux/buildah/project.md.liquid
+++ b/bin/configurator/static/_includes/ru/configurator/tab/ci/gitlab-ci-cd/best-practice/with-per-repo-ci-cd/monorepo/docker-runner/linux/buildah/project.md.liquid
@@ -36,7 +36,7 @@
 
 Так может выглядеть репозиторий, использующий werf для сборки и развертывания:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/ci-cd/best-practice/with-per-repo-ci-cd/gitlab-ci-cd/monorepo/docker-runner/linux/buildah?module=/.gitlab-ci.yml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/ci-cd/best-practice/with-per-repo-ci-cd/gitlab-ci-cd/monorepo/docker-runner/linux/buildah' module='/.gitlab-ci.yml' %}
 
 {% capture registry_guide_url %}/documentation/v1.2/usage/cleanup/cr_cleanup.html#%D0%BE%D1%81%D0%BE%D0%B1%D0%B5%D0%BD%D0%BD%D0%BE%D1%81%D1%82%D0%B8-%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D1%8B-%D1%81-%D1%80%D0%B0%D0%B7%D0%BB%D0%B8%D1%87%D0%BD%D1%8B%D0%BC%D0%B8-container-registries{% endcapture %}
 Дополнительно:

--- a/bin/configurator/static/_includes/ru/configurator/tab/ci/gitlab-ci-cd/best-practice/with-per-repo-ci-cd/monorepo/host-runner/linux/buildah/project.md.liquid
+++ b/bin/configurator/static/_includes/ru/configurator/tab/ci/gitlab-ci-cd/best-practice/with-per-repo-ci-cd/monorepo/host-runner/linux/buildah/project.md.liquid
@@ -40,7 +40,7 @@
 
 Так может выглядеть репозиторий, использующий werf для сборки и развертывания:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/ci-cd/best-practice/with-per-repo-ci-cd/gitlab-ci-cd/monorepo/host-runner/linux/buildah?module=/.gitlab-ci.yml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/ci-cd/best-practice/with-per-repo-ci-cd/gitlab-ci-cd/monorepo/host-runner/linux/buildah' module='/.gitlab-ci.yml' %}
 
 {% capture registry_guide_url %}/documentation/v1.2/usage/cleanup/cr_cleanup.html#%D0%BE%D1%81%D0%BE%D0%B1%D0%B5%D0%BD%D0%BD%D0%BE%D1%81%D1%82%D0%B8-%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D1%8B-%D1%81-%D1%80%D0%B0%D0%B7%D0%BB%D0%B8%D1%87%D0%BD%D1%8B%D0%BC%D0%B8-container-registries{% endcapture %}
 Дополнительно:

--- a/bin/configurator/static/_includes/ru/configurator/tab/ci/gitlab-ci-cd/best-practice/with-per-repo-ci-cd/monorepo/host-runner/linux/docker/project.md.liquid
+++ b/bin/configurator/static/_includes/ru/configurator/tab/ci/gitlab-ci-cd/best-practice/with-per-repo-ci-cd/monorepo/host-runner/linux/docker/project.md.liquid
@@ -36,7 +36,7 @@
 
 Так может выглядеть репозиторий, использующий werf для сборки и развертывания:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/ci-cd/best-practice/with-per-repo-ci-cd/gitlab-ci-cd/monorepo/host-runner/linux/docker?module=/.gitlab-ci.yml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/ci-cd/best-practice/with-per-repo-ci-cd/gitlab-ci-cd/monorepo/host-runner/linux/docker' module='/.gitlab-ci.yml' %}
 
 {% capture registry_guide_url %}/documentation/v1.2/usage/cleanup/cr_cleanup.html#%D0%BE%D1%81%D0%BE%D0%B1%D0%B5%D0%BD%D0%BD%D0%BE%D1%81%D1%82%D0%B8-%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D1%8B-%D1%81-%D1%80%D0%B0%D0%B7%D0%BB%D0%B8%D1%87%D0%BD%D1%8B%D0%BC%D0%B8-container-registries{% endcapture %}
 Дополнительно:

--- a/bin/configurator/static/_includes/ru/configurator/tab/ci/gitlab-ci-cd/best-practice/with-per-repo-ci-cd/monorepo/kubernetes-runner/linux/buildah/project.md.liquid
+++ b/bin/configurator/static/_includes/ru/configurator/tab/ci/gitlab-ci-cd/best-practice/with-per-repo-ci-cd/monorepo/kubernetes-runner/linux/buildah/project.md.liquid
@@ -36,7 +36,7 @@
 
 Так может выглядеть репозиторий, использующий werf для сборки и развертывания:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/ci-cd/best-practice/with-per-repo-ci-cd/gitlab-ci-cd/monorepo/kubernetes-runner/linux/buildah?module=/.gitlab-ci.yml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/ci-cd/best-practice/with-per-repo-ci-cd/gitlab-ci-cd/monorepo/kubernetes-runner/linux/buildah' module='/.gitlab-ci.yml' %}
 
 {% capture registry_guide_url %}/documentation/v1.2/usage/cleanup/cr_cleanup.html#%D0%BE%D1%81%D0%BE%D0%B1%D0%B5%D0%BD%D0%BD%D0%BE%D1%81%D1%82%D0%B8-%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D1%8B-%D1%81-%D1%80%D0%B0%D0%B7%D0%BB%D0%B8%D1%87%D0%BD%D1%8B%D0%BC%D0%B8-container-registries{% endcapture %}
 Дополнительно:

--- a/bin/configurator/static/_includes/ru/configurator/tab/ci/gitlab-ci-cd/simple/docker-runner/linux/buildah/project.md.liquid
+++ b/bin/configurator/static/_includes/ru/configurator/tab/ci/gitlab-ci-cd/simple/docker-runner/linux/buildah/project.md.liquid
@@ -26,7 +26,7 @@
 
 Так может выглядеть репозиторий, использующий werf для сборки и развертывания:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/ci-cd/simple/gitlab-ci-cd/docker-runner/linux/buildah?module=/.gitlab-ci.yml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/ci-cd/simple/gitlab-ci-cd/docker-runner/linux/buildah' module='/.gitlab-ci.yml' %}
 
 {% capture registry_guide_url %}/documentation/v1.2/usage/cleanup/cr_cleanup.html#%D0%BE%D1%81%D0%BE%D0%B1%D0%B5%D0%BD%D0%BD%D0%BE%D1%81%D1%82%D0%B8-%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D1%8B-%D1%81-%D1%80%D0%B0%D0%B7%D0%BB%D0%B8%D1%87%D0%BD%D1%8B%D0%BC%D0%B8-container-registries{% endcapture %}
 Дополнительно:

--- a/bin/configurator/static/_includes/ru/configurator/tab/ci/gitlab-ci-cd/simple/host-runner/linux/buildah/project.md.liquid
+++ b/bin/configurator/static/_includes/ru/configurator/tab/ci/gitlab-ci-cd/simple/host-runner/linux/buildah/project.md.liquid
@@ -26,7 +26,7 @@
 
 Так может выглядеть репозиторий, использующий werf для сборки и развертывания:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/ci-cd/simple/gitlab-ci-cd/host-runner/linux/buildah?module=/.gitlab-ci.yml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/ci-cd/simple/gitlab-ci-cd/host-runner/linux/buildah' module='/.gitlab-ci.yml' %}
 
 {% capture registry_guide_url %}/documentation/v1.2/usage/cleanup/cr_cleanup.html#%D0%BE%D1%81%D0%BE%D0%B1%D0%B5%D0%BD%D0%BD%D0%BE%D1%81%D1%82%D0%B8-%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D1%8B-%D1%81-%D1%80%D0%B0%D0%B7%D0%BB%D0%B8%D1%87%D0%BD%D1%8B%D0%BC%D0%B8-container-registries{% endcapture %}
 Дополнительно:

--- a/bin/configurator/static/_includes/ru/configurator/tab/ci/gitlab-ci-cd/simple/host-runner/linux/docker/project.md.liquid
+++ b/bin/configurator/static/_includes/ru/configurator/tab/ci/gitlab-ci-cd/simple/host-runner/linux/docker/project.md.liquid
@@ -26,7 +26,7 @@
 
 Так может выглядеть репозиторий, использующий werf для сборки и развертывания:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/ci-cd/simple/gitlab-ci-cd/docker-runner/linux/docker?module=/.gitlab-ci.yml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/ci-cd/simple/gitlab-ci-cd/docker-runner/linux/docker' module='/.gitlab-ci.yml' %}
 
 {% capture registry_guide_url %}/documentation/v1.2/usage/cleanup/cr_cleanup.html#%D0%BE%D1%81%D0%BE%D0%B1%D0%B5%D0%BD%D0%BD%D0%BE%D1%81%D1%82%D0%B8-%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D1%8B-%D1%81-%D1%80%D0%B0%D0%B7%D0%BB%D0%B8%D1%87%D0%BD%D1%8B%D0%BC%D0%B8-container-registries{% endcapture %}
 Дополнительно:

--- a/bin/configurator/static/_includes/ru/configurator/tab/ci/gitlab-ci-cd/simple/kubernetes-runner/linux/buildah/project.md.liquid
+++ b/bin/configurator/static/_includes/ru/configurator/tab/ci/gitlab-ci-cd/simple/kubernetes-runner/linux/buildah/project.md.liquid
@@ -26,7 +26,7 @@
 
 Так может выглядеть репозиторий, использующий werf для сборки и развертывания:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/ci-cd/simple/gitlab-ci-cd/kubernetes-runner/linux/buildah?module=/.gitlab-ci.yml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/ci-cd/simple/gitlab-ci-cd/kubernetes-runner/linux/buildah' module='/.gitlab-ci.yml' %}
 
 {% capture registry_guide_url %}/documentation/v1.2/usage/cleanup/cr_cleanup.html#%D0%BE%D1%81%D0%BE%D0%B1%D0%B5%D0%BD%D0%BD%D0%BE%D1%81%D1%82%D0%B8-%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D1%8B-%D1%81-%D1%80%D0%B0%D0%B7%D0%BB%D0%B8%D1%87%D0%BD%D1%8B%D0%BC%D0%B8-container-registries{% endcapture %}
 Дополнительно:

--- a/bin/configurator/static/_includes/ru/configurator/tab/ci/other-ci-cd-system/simple/docker-runner/linux/buildah/project.md.liquid
+++ b/bin/configurator/static/_includes/ru/configurator/tab/ci/other-ci-cd-system/simple/docker-runner/linux/buildah/project.md.liquid
@@ -2,7 +2,7 @@
 
 Так может выглядеть репозиторий, использующий werf для сборки и развертывания:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/ci-cd/simple/other/docker-runner/linux/buildah?module=/pseudo-ci-cd-config.yaml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/ci-cd/simple/other/docker-runner/linux/buildah' module='/pseudo-ci-cd-config.yaml' %}
 
 {% capture registry_guide_url %}/documentation/v1.2/usage/cleanup/cr_cleanup.html#%D0%BE%D1%81%D0%BE%D0%B1%D0%B5%D0%BD%D0%BD%D0%BE%D1%81%D1%82%D0%B8-%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D1%8B-%D1%81-%D1%80%D0%B0%D0%B7%D0%BB%D0%B8%D1%87%D0%BD%D1%8B%D0%BC%D0%B8-container-registries{% endcapture %}
 Дополнительно:

--- a/bin/configurator/static/_includes/ru/configurator/tab/ci/other-ci-cd-system/simple/host-runner/linux/buildah/project.md.liquid
+++ b/bin/configurator/static/_includes/ru/configurator/tab/ci/other-ci-cd-system/simple/host-runner/linux/buildah/project.md.liquid
@@ -2,7 +2,7 @@
 
 Так может выглядеть репозиторий, использующий werf для сборки и развертывания:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/ci-cd/simple/other/host-runner/linux/buildah?module=/pseudo-ci-cd-config.yaml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/ci-cd/simple/other/host-runner/linux/buildah' module='/pseudo-ci-cd-config.yaml' %}
 
 {% capture registry_guide_url %}/documentation/v1.2/usage/cleanup/cr_cleanup.html#%D0%BE%D1%81%D0%BE%D0%B1%D0%B5%D0%BD%D0%BD%D0%BE%D1%81%D1%82%D0%B8-%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D1%8B-%D1%81-%D1%80%D0%B0%D0%B7%D0%BB%D0%B8%D1%87%D0%BD%D1%8B%D0%BC%D0%B8-container-registries{% endcapture %}
 Дополнительно:

--- a/bin/configurator/static/_includes/ru/configurator/tab/ci/other-ci-cd-system/simple/host-runner/linux/docker/project.md.liquid
+++ b/bin/configurator/static/_includes/ru/configurator/tab/ci/other-ci-cd-system/simple/host-runner/linux/docker/project.md.liquid
@@ -2,7 +2,7 @@
 
 Так может выглядеть репозиторий, использующий werf для сборки и развертывания:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/ci-cd/simple/other/host-runner/linux/docker?module=/pseudo-ci-cd-config.yaml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/ci-cd/simple/other/host-runner/linux/docker' module='/pseudo-ci-cd-config.yaml' %}
 
 {% capture registry_guide_url %}/documentation/v1.2/usage/cleanup/cr_cleanup.html#%D0%BE%D1%81%D0%BE%D0%B1%D0%B5%D0%BD%D0%BD%D0%BE%D1%81%D1%82%D0%B8-%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D1%8B-%D1%81-%D1%80%D0%B0%D0%B7%D0%BB%D0%B8%D1%87%D0%BD%D1%8B%D0%BC%D0%B8-container-registries{% endcapture %}
 Дополнительно:

--- a/bin/configurator/static/_includes/ru/configurator/tab/ci/other-ci-cd-system/simple/kubernetes-runner/linux/buildah/project.md.liquid
+++ b/bin/configurator/static/_includes/ru/configurator/tab/ci/other-ci-cd-system/simple/kubernetes-runner/linux/buildah/project.md.liquid
@@ -2,7 +2,7 @@
 
 Так может выглядеть репозиторий, использующий werf для сборки и развертывания:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/ci-cd/simple/other/kubernetes-runner/linux/buildah?module=/pseudo-ci-cd-config.yaml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/ci-cd/simple/other/kubernetes-runner/linux/buildah' module='/pseudo-ci-cd-config.yaml' %}
 
 {% capture registry_guide_url %}/documentation/v1.2/usage/cleanup/cr_cleanup.html#%D0%BE%D1%81%D0%BE%D0%B1%D0%B5%D0%BD%D0%BD%D0%BE%D1%81%D1%82%D0%B8-%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D1%8B-%D1%81-%D1%80%D0%B0%D0%B7%D0%BB%D0%B8%D1%87%D0%BD%D1%8B%D0%BC%D0%B8-container-registries{% endcapture %}
 Дополнительно:

--- a/bin/configurator/static/_includes/ru/configurator/tab/dev/linux/buildah/run.md.liquid
+++ b/bin/configurator/static/_includes/ru/configurator/tab/dev/linux/buildah/run.md.liquid
@@ -10,7 +10,7 @@
 
 Содержимое демо-проекта:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/local-dev?module=/werf.yaml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/local-dev' module='/werf.yaml' %}
 
 Инициализируйте демо-проект на локальной машине:
 

--- a/bin/configurator/static/_includes/ru/configurator/tab/dev/linux/docker/run.md.liquid
+++ b/bin/configurator/static/_includes/ru/configurator/tab/dev/linux/docker/run.md.liquid
@@ -10,7 +10,7 @@
 
 Содержимое демо-проекта:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/local-dev?module=/werf.yaml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/local-dev' module='/werf.yaml' %}
 
 Инициализируйте демо-проект на локальной машине:
 

--- a/bin/configurator/static/_includes/ru/configurator/tab/dev/macos/docker/run.md.liquid
+++ b/bin/configurator/static/_includes/ru/configurator/tab/dev/macos/docker/run.md.liquid
@@ -10,7 +10,7 @@
 
 Содержимое демо-проекта:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/local-dev?module=/werf.yaml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/local-dev' module='/werf.yaml' %}
 
 Инициализируйте демо-проект на локальной машине:
 

--- a/bin/configurator/static/_includes/ru/configurator/tab/dev/windows/docker/run.md.liquid
+++ b/bin/configurator/static/_includes/ru/configurator/tab/dev/windows/docker/run.md.liquid
@@ -10,7 +10,7 @@
 
 Содержимое демо-проекта:
 
-<iframe src="https://codesandbox.io/embed/github/werf/examples/tree/main/local-dev?module=/werf.yaml&codemirror=1&autoresize=1&fontsize=13&runonclick=1&theme=dark&view=editor&hidenavigation=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+{% include /common/configurator/codesandbox.html github_path='github/werf/examples/tree/main/local-dev' module='/werf.yaml' %}
 
 Инициализируйте демо-проект на локальной машине:
 


### PR DESCRIPTION
- Set iframe width to minimal width when codesandbox shows a sidebar https://github.com/codesandbox/codesandbox-client/blob/389073613e06eee944231f4aeef9dfa746c1b947/packages/app/src/embed/util/constants.js https://github.com/codesandbox/codesandbox-client/blob/389073613e06eee944231f4aeef9dfa746c1b947/packages/app/src/embed/components/App/index.js#L99
- Use wrapper to show iframe inside a narrower column.
- Move iframe off the screen for lazy loading.


<img width="1191" alt="image" src="https://user-images.githubusercontent.com/1055474/233496571-a9d02132-5864-4411-9c21-7b94d24da9a0.png">

'Open sandbox' button is hidden now, but 'Edit sandbox' button is the same.