### PR TITLE
chore: disallow indexing werf 1.1 by search engines

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -8,11 +8,11 @@ User-agent: *
 Disallow: *.js
 Disallow: *?*
 Allow: /
-Allow: /documentation/v1.1
 Allow: /documentation/v1.2
+Disallow: /documentation/v1.1
 Disallow: /documentation/v
+Disallow: /documentation/v1.2-
 Disallow: /documentation/v1.2.
-Disallow: /documentation/v1.1.
 Disallow: /configurator/tabs
 Sitemap: {{ site.url }}/sitemap.xml
 Host: {{ site.url }}


### PR DESCRIPTION
Update robots.txt to disallow indexing werf 1.1 by search engines.