### PR TITLE
Add local htmlproofer

### DIFF
--- a/.github/workflows/content_validation.yml
+++ b/.github/workflows/content_validation.yml
@@ -12,39 +12,31 @@ env:
   WERF_ENV: "production"
 
 jobs:
-  check_links:
-    container: jekyll/builder:4.2.0
-    name: Check broken links
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        lang: [ ru, en ]
+  check_broken_links:
+    runs-on: ubuntu-latest-4-cores
+    timeout-minutes: 60
     steps:
+      - name: Install werf
+        uses: werf/actions/install@v1.2
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
         with:
-          fetch-depth: 0
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Prepare environment
-        run: |
-          chmod 777 Gemfile.lock
-          bundle install
-          mkdir -pm 777 .jekyll-cache .jekyll-cache-en .jekyll-cache-ru _site
-          chmod -R 777 assets/images/plantuml_cache
-
-      - name: Build
-        run: bundle exec jekyll build --config _config.yml,_config_dev.yml,_config_${{ matrix.lang }}.yml --destination _site/
+      - name: Login to GitHub container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check links
         run: |
-          bundle exec htmlproofer \
-            --allow-hash-href \
-            --empty-alt-ignore \
-            --check_html \
-            --file_ignore "/____________/" \
-            --url_ignore "/localhost/,/t.me/,/slack.com/,/cncf.io/,/example.com/,/github.com\/werf\/website\/edit/,/habr.com/,/apple-touch-icon.png/,/site.webmanifest/,/favicon/,/safari-pinned-tab/,/documentation/,/guides.html/" \
-            --url-swap "github.com/werf/website/blob/main:github.com/werf/website/blob/$GITHUB_SHA,github.com/werf/website/tree/main:github.com/werf/website/tree/$GITHUB_SHA" \
-            --http-status-ignore "0,429,403" \
-            ./_site/
+          source "$(werf ci-env github --as-file)"
+          task -o group -p site:check-broken-links
+        env:
+          WERF_REPO: "ghcr.io/${{ github.repository_owner }}/werfio"

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -171,19 +171,19 @@ tasks:
         WERF_BACKEND_DOCKER_IMAGE_NAME=nginx:latest \
         werf compose down
 
-  links:check-broken-links:
+  site:check-broken-links:
     desc: 'Check docs for broken links.'
     deps:
-      - links:check-broken-links:ru
-      - links:check-broken-links:en
+      - site:check-broken-links:ru
+      - site:check-broken-links:en
 
-  links:check-broken-links:ru:
+  site:check-broken-links:ru:
     desc: 'Check ru docs for broken links.'
     cmds:
       - |
         ./scripts/docs/check_broken_links.sh ru
 
-  links:check-broken-links:en:
+  site:check-broken-links:en:
     desc: 'Check en docs for broken links.'
     cmds:
       - |

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -13,7 +13,7 @@ tasks:
   # default:
   #   cmds:
   #     - task: xxx
-  
+
   format:
     desc: 'Run all code formatters. Important vars: "paths".'
     run: once
@@ -170,3 +170,21 @@ tasks:
         WERF_JEKYLL_BASE_DOCKER_IMAGE_NAME=nginx:latest \
         WERF_BACKEND_DOCKER_IMAGE_NAME=nginx:latest \
         werf compose down
+
+  links:check-broken-links:
+    desc: 'Check docs for broken links.'
+    deps:
+      - links:check-broken-links:ru
+      - links:check-broken-links:en
+
+  links:check-broken-links:ru:
+    desc: 'Check ru docs for broken links.'
+    cmds:
+      - |
+        ./scripts/docs/check_broken_links.sh ru
+
+  links:check-broken-links:en:
+    desc: 'Check en docs for broken links.'
+    cmds:
+      - |
+        ./scripts/docs/check_broken_links.sh en

--- a/scripts/docs/check_broken_links.sh
+++ b/scripts/docs/check_broken_links.sh
@@ -12,7 +12,8 @@ cd /app && \
     --check_html \
     --file_ignore "/____________/" \
     --url_ignore "/localhost/,/t.me/,/slack.com/,/cncf.io/,/example.com/,/github.com/werf/,/habr.com/,/apple-touch-icon.png/,/site.webmanifest/,/favicon/,/safari-pinned-tab/,/documentation/,/guides.html/" \
-    --http-status-ignore "0,429,403,500" \
+    --url-swap "github.com/werf/website/blob/main:github.com/werf/website/blob/$GITHUB_SHA,github.com/werf/website/tree/main:github.com/werf/website/tree/$GITHUB_SHA" \
+    --http-status-ignore "0,429,403" \
     /app/_site
 EOF
 )

--- a/scripts/docs/check_broken_links.sh
+++ b/scripts/docs/check_broken_links.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+arg_site_lang="${1:?ERROR: Site language \'en\' or \'ru\' should be specified as the first argument.}"
+
+script=$(cat <<EOF
+cd /app && \
+  bundle exec htmlproofer \
+    --allow-hash-href \
+    --empty-alt-ignore \
+    --check_html \
+    --file_ignore "/____________/" \
+    --url_ignore "/localhost/,/t.me/,/slack.com/,/cncf.io/,/example.com/,/github.com/werf/,/habr.com/,/apple-touch-icon.png/,/site.webmanifest/,/favicon/,/safari-pinned-tab/,/documentation/,/guides.html/" \
+    --http-status-ignore "0,429,403,500" \
+    /app/_site
+EOF
+)
+
+werf run doc_$arg_site_lang --dev --docker-options="--entrypoint=bash" -- -c "$script"

--- a/scripts/docs/check_broken_links.sh
+++ b/scripts/docs/check_broken_links.sh
@@ -17,4 +17,4 @@ cd /app && \
 EOF
 )
 
-werf run doc_$arg_site_lang --dev --docker-options="--entrypoint=bash" -- -c "$script"
+werf run doc_$arg_site_lang --docker-options="--entrypoint=bash" -- -c "$script"


### PR DESCRIPTION
Added local link checking:

- `task site:check-broken-links` – checks both versions — en and ru;
- `task site:check-broken-links:ru` – checks only ru docs;
- `task site:check-broken-links:en` – checks only en docs.

Launches a container from `werf.yaml`, and it checks the generated site.