### PR TITLE
Add a target file selection for spell checking

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -156,13 +156,13 @@ tasks:
       - site:run-spell-check:en
 
   site:run-spell-check:ru:
-    desc: 'Run spell check for ru pages.'
+    desc: 'Run spell check for ru pages. You can specify the path to a specific file with `-- ./path/to/file`'
     cmds:
       - |
         ./scripts/docs/spelling/spell_check.sh ru {{.CLI_ARGS}}
 
   site:run-spell-check:en:
-    desc: 'Run spell check for en pages.'
+    desc: 'Run spell check for en pages. You can specify the path to a specific file with `-- ./path/to/file`'
     cmds:
       - |
         ./scripts/docs/spelling/spell_check.sh en {{.CLI_ARGS}}

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -159,13 +159,13 @@ tasks:
     desc: 'Run spell check for ru pages.'
     cmds:
       - |
-        ./scripts/docs/spelling/spell_check.sh ru
+        ./scripts/docs/spelling/spell_check.sh ru {{.CLI_ARGS}}
 
   site:run-spell-check:en:
     desc: 'Run spell check for en pages.'
     cmds:
       - |
-        ./scripts/docs/spelling/spell_check.sh en
+        ./scripts/docs/spelling/spell_check.sh en {{.CLI_ARGS}}
 
   site:generate-special-dictionary:
     desc: 'Generate a dictionary of special terms.'

--- a/scripts/docs/spelling/internal/container_spell_check.sh
+++ b/scripts/docs/spelling/internal/container_spell_check.sh
@@ -11,6 +11,10 @@ elif [[ "$arg_site_lang" == "ru" ]]; then
   language="ru_RU,en_US,dev_OPS"
 fi
 
+if [ -n "$2" ]; then
+  arg_target_page=$2
+fi
+
 cp /usr/share/hunspell/en_US.aff  /usr/share/hunspell/en_US.aff.orig
 cp /usr/share/hunspell/en_US.dic  /usr/share/hunspell/en_US.dic.orig
 iconv --from ISO8859-1 /usr/share/hunspell/en_US.aff.orig > /usr/share/hunspell/en_US.aff
@@ -21,9 +25,14 @@ sed -i 's/SET ISO8859-1/SET UTF-8/' /usr/share/hunspell/en_US.aff
 
 echo "Checking $arg_site_lang docs..."
 
-for file in `find ./ -type f -name "*.html"`
-do
-  echo "$str"
-  echo "Checking $file..."
-  python3 clear_html_from_code.py $file | html2text -utf8 | sed '/^$/d' | hunspell -d $language -l
-done
+if [ -n "$2" ]; then
+  echo "Checking $arg_target_page..."
+  python3 clear_html_from_code.py $arg_target_page | html2text -utf8 | sed '/^$/d' | hunspell -d $language -l
+else
+  for file in `find ./ -type f -name "*.html"`
+  do
+    echo "$str"
+    echo "Checking $file..."
+    python3 clear_html_from_code.py $file | html2text -utf8 | sed '/^$/d' | hunspell -d $language -l
+  done
+fi

--- a/scripts/docs/spelling/spell_check.sh
+++ b/scripts/docs/spelling/spell_check.sh
@@ -4,9 +4,13 @@ set -e
 
 arg_site_lang="${1:?ERROR: Site language \'en\' or \'ru\' should be specified as the first argument.}"
 
+if [ -n "$2" ]; then
+  arg_target_page=$2
+fi
+
 script=$(cat <<EOF
 cd /spelling/$arg_site_lang && \
-  ./container_spell_check.sh $arg_site_lang
+  ./container_spell_check.sh $arg_site_lang $arg_target_page
 EOF
 )
 


### PR DESCRIPTION
Added a parameter through which you can pass the path to the file to check it.

For example: `task site:run-spell-check:ru -- ./guides.html`.