### PR TITLE
Add generation of a general list of typos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ bin/configurator/generated/
 /scripts/demo/sample-app
 configurator-data.json
 configurator-options-list.json
+spell_log_ru
+spell_log_en

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -181,3 +181,21 @@ tasks:
     cmds:
       - |
         sort -u -f -o ./scripts/docs/spelling/wordlist{,}
+
+  site:get-words-with-typos:
+    desc: 'Pulls out a list of all the terms in all pages that were considered a typo'
+    deps:
+      - site:get-words-with-typos:ru
+      - site:get-words-with-typos:en
+
+  site:get-words-with-typos:ru:
+    desc: 'Pulls out a list of all the terms in RU pages that were considered a typo'
+    cmds:
+      - |
+        task site:run-spell-check:ru | sed '1,/Checking/ d' | sed '/^$/d' | sed '/Checking/d' | sort -u > spell_log_ru
+
+  site:get-words-with-typos:en:
+    desc: 'Pulls out a list of all the terms in EN pages that were considered a typo'
+    cmds:
+      - |
+        task site:run-spell-check:en | sed '1,/Checking/ d' | sed '/^$/d' | sed '/Checking/d' | sort -u > spell_log_en


### PR DESCRIPTION
Added three commands to Taskfile:
* `site:get-words-with-typos:ru`
* `site:get-words-with-typos:en`
* `site:get-words-with-typos`

They get a sorted list of all the typos found and save it to the `spell_log_en` and `spell_log_ru` files.

These files are added to `.gitignore` and are designed for local work with dictionaries.