### PR TITLE
Add configurator pages to sitemaps

### DIFF
--- a/_data/_common/install_sitemap.yml
+++ b/_data/_common/install_sitemap.yml
@@ -1,0 +1,8 @@
+links:
+  - "usage=localDev&os=linux&buildBackend=buildah"
+  - "usage=localDev&os=macos&buildBackend=docker"
+  - "usage=localDev&os=windows&buildBackend=docker"
+  - "usage=ci&ci=gitlabCiCd&runnerType=kubernetesRunner&os=linux&buildBackend=buildah&projectType=bestPractice&sharedCICD=no&repoType=application"
+  - "usage=ci&ci=githubActions&runnerType=hostRunner&os=linux&buildBackend=docker&projectType=simplified&sharedCICD=no&repoType=application"
+  - "usage=ci&ci=otherCiCdSystem&runnerType=dockerRunner&os=linux&buildBackend=buildah&projectType=simplified&sharedCICD=no&repoType=application"
+  - "usage=ci&ci=argoCdWithGitlabCiCd&runnerType=dockerRunner&os=linux&buildBackend=buildah&projectType=simplified&sharedCICD=no&repoType=application"

--- a/sitemap-site.xml
+++ b/sitemap-site.xml
@@ -20,7 +20,7 @@ search: exclude
     </url>
     {%- endfor %}
 
-    {%- assign configurator_links = site.data.common.configurator_sitemap.links %}
+    {%- assign configurator_links = site.data.common.install_sitemap.links %}
     {%- for link in configurator_links %}
     <url>
         <loc>{{ site.url }}/documentation/v1.2/index.html?{{ link }}</loc>

--- a/sitemap-site.xml
+++ b/sitemap-site.xml
@@ -19,4 +19,17 @@ search: exclude
         <priority>0.5</priority>
     </url>
     {%- endfor %}
+
+    {%- assign configurator_links = site.data.common.configurator_sitemap.links %}
+    {%- for link in configurator_links %}
+    <url>
+        <loc>{{ site.url }}/documentation/v1.2/index.html?{{ link }}</loc>
+        <xhtml:link rel="alternate" hreflang="ru" href="{{ site.site_urls.ru }}/documentation/v1.2/index.html?{{ link }}" />
+        <xhtml:link rel="alternate" hreflang="en" href="{{ site.site_urls.en }}/documentation/v1.2/index.html?{{ link }}" />
+        <lastmod>{{site.time | date: '%Y-%m-%d' }}</lastmod>
+        <changefreq>daily</changefreq>
+        <priority>0.5</priority>
+    </url>
+    {%- endfor %}
+
 </urlset>


### PR DESCRIPTION
Added link generation of the configurator pages in sitemaps.

The links are located in the file `_data/_common/install_sitemap.yml`:

```yaml
links:
  - "usage=localDev&os=linux&buildBackend=buildah"
  - "usage=localDev&os=macos&buildBackend=docker"
  - "usage=localDev&os=windows&buildBackend=docker"
...
```
The result in the sitemap:
```xml
    <url>
        <loc>https://werf.io/documentation/v1.2/index.html?usage=localDev&os=linux&buildBackend=buildah</loc>
        <xhtml:link rel="alternate" hreflang="ru" href="https://ru.werf.io/documentation/v1.2/index.html?usage=localDev&os=linux&buildBackend=buildah" />
        <xhtml:link rel="alternate" hreflang="en" href="https://werf.io/documentation/v1.2/index.html?usage=localDev&os=linux&buildBackend=buildah" />
        <lastmod>2023-07-11</lastmod>
        <changefreq>daily</changefreq>
        <priority>0.5</priority>
    </url>
    <url>
        <loc>https://werf.io/documentation/v1.2/index.html?usage=localDev&os=macos&buildBackend=docker</loc>
        <xhtml:link rel="alternate" hreflang="ru" href="https://ru.werf.io/documentation/v1.2/index.html?usage=localDev&os=macos&buildBackend=docker" />
        <xhtml:link rel="alternate" hreflang="en" href="https://werf.io/documentation/v1.2/index.html?usage=localDev&os=macos&buildBackend=docker" />
        <lastmod>2023-07-11</lastmod>
        <changefreq>daily</changefreq>
        <priority>0.5</priority>
    </url>
```