### PR TITLE
Add language indication to spell checker

### DIFF
--- a/scripts/docs/spelling/internal/container_spell_check.sh
+++ b/scripts/docs/spelling/internal/container_spell_check.sh
@@ -7,8 +7,10 @@ str=$'\n'
 
 if [[ "$arg_site_lang" == "en" ]]; then
   language="en_US,dev_OPS"
+  indicator="EN"
 elif [[ "$arg_site_lang" == "ru" ]]; then
   language="ru_RU,en_US,dev_OPS"
+  indicator="RU"
 fi
 
 if [ -n "$2" ]; then
@@ -36,7 +38,7 @@ else
   for file in `find ./ -type f -name "*.html"`
   do
     echo "$str"
-    echo "Checking $file..."
+    echo "$indicator: checking $file..."
     python3 clear_html_from_code.py $file | html2text -utf8 | sed '/^$/d' | hunspell -d $language -l
   done
 fi


### PR DESCRIPTION
An indication of the language of the file being checked has been added. This is necessary in order to better understand in which content the error was found, in Russian or English.

Previously, the result looked like this:
```
Checking ./configurator/tabs/usage-ci_ci-gitlabCiCd_runnerType-hostRunner_os-linux_buildBackend-buildah_projectType-bestPractice_sharedCICD-no_repoType-monorepo.html...
qemu
yaml
yaml
json
json
js
gitlab
ci
yaml


Checking ./configurator/tabs/usage-ci_ci-otherCiCdSystem_runnerType-hostRunner_os-linux_buildBackend-buildah_projectType-simplified_sharedCICD-no_repoType-application.html...
qemu
yaml
yaml
json
json
js
ci
cd
yaml
yaml
```
Now the result looks like this:
```
EN: checking ./configurator/tabs/usage-ci_ci-gitlabCiCd_runnerType-hostRunner_os-linux_buildBackend-buildah_projectType-bestPractice_sharedCICD-no_repoType-monorepo.html...
qemu
yaml
yaml
json
json
js
gitlab
ci
yaml


RU: checking ./configurator/tabs/usage-ci_ci-otherCiCdSystem_runnerType-hostRunner_os-linux_buildBackend-buildah_projectType-simplified_sharedCICD-no_repoType-application.html...
qemu
yaml
yaml
json
json
js
ci
cd
yaml
yaml
```