### PR TITLE
Add file and path exclusion to the spelcheck

### DIFF
--- a/scripts/docs/spelling/internal/container_spell_check.sh
+++ b/scripts/docs/spelling/internal/container_spell_check.sh
@@ -28,17 +28,48 @@ sed -i 's/SET ISO8859-1/SET UTF-8/' /usr/share/hunspell/en_US.aff
 echo "Checking $arg_site_lang docs..."
 
 if [ -n "$2" ]; then
-  echo "Checking $arg_target_page..."
   if [ -n "$3" ]; then
     python3 clear_html_from_code.py $arg_target_page | html2text -utf8 | sed '/^$/d'
   else
-    python3 clear_html_from_code.py $arg_target_page | html2text -utf8 | sed '/^$/d' | hunspell -d $language -l
+    check=1
+    if test -f "filesignore"; then
+      while read y; do
+        if [[ "$arg_target_page" =~ "$y" ]]; then
+          unset check
+          check=0
+        fi
+      done <<-__EOF__
+  $(cat ./filesignore)
+__EOF__
+      if [ "$check" -eq 1 ]; then
+        echo "Checking $arg_target_page..."
+        python3 clear_html_from_code.py $arg_target_page | html2text -utf8 | sed '/^$/d' | hunspell -d $language -l
+      else
+        echo "Ignoring $arg_target_page..."
+      fi
+    fi
   fi
 else
   for file in `find ./ -type f -name "*.html"`
   do
-    echo "$str"
-    echo "$indicator: checking $file..."
-    python3 clear_html_from_code.py $file | html2text -utf8 | sed '/^$/d' | hunspell -d $language -l
+    check=1
+    if test -f "filesignore"; then
+      while read y; do
+        if [[ "$file" =~ "$y" ]]; then
+          unset check
+          check=0
+        fi
+      done <<-__EOF__
+  $(cat ./filesignore)
+__EOF__
+      if [ "$check" -eq 1 ]; then
+        echo "$str"
+        echo "$indicator: checking $file..."
+        python3 clear_html_from_code.py $file | html2text -utf8 | sed '/^$/d' | hunspell -d $language -l
+      else
+        echo "$str"
+        echo "Ignoring $indicator: $file..."
+      fi
+    fi
   done
 fi

--- a/scripts/docs/spelling/internal/filesignore
+++ b/scripts/docs/spelling/internal/filesignore
@@ -1,0 +1,1 @@
+assets/demo


### PR DESCRIPTION
Added checking for exceptions that do not fall into the spell check.

The list of file paths to exclude is in the `scripts/docs/spelling/internal/filesignore` file. Paths are checked by a match mask. There is a separate mask on each line of the file.

For example:

* By the `guides` mask, all pages in the `/guides` section will be excluded from the check.
* By the `guides/django` mask, all pages in the `/guides/django` section will be excluded from the check.
* By mask `guides/nodejs/400_ci_cd_workflow/040_github_actions.html`a specific file will be excluded.

Currently, files from the `assets/demo` directory are excluded from the check.
