### PR TITLE
[spell-check] Add functionality to remove parts of a page from HTML

### DIFF
--- a/_includes/_common/footer.html
+++ b/_includes/_common/footer.html
@@ -2,7 +2,7 @@
     <div class="page__container">
         <div class="footer__wrap">
             <div class="footer__block-cncf">
-                <!-- spell-delete -->
+                <!-- spell-check-ignore -->
                 <a href="https://www.cncf.io/projects/werf/" target="_blank">
                     <img src="/assets/images/cncf-logo.svg" alt="cncf logo">
                     {%- if page.lang == "ru" %}
@@ -11,7 +11,7 @@
                         <div class="footer__block-cncf-text">werf is a Cloud Native Computing Foundation sandbox project</div>
                     {%- endif %}
                 </a>
-                <!-- end-spell-delete -->
+                <!-- end-spell-check-ignore -->
             </div>
             <div class="footer__block-flant">
                 {%- if page.lang == "ru" %}

--- a/_includes/_common/footer.html
+++ b/_includes/_common/footer.html
@@ -2,6 +2,7 @@
     <div class="page__container">
         <div class="footer__wrap">
             <div class="footer__block-cncf">
+                <!-- spell-delete -->
                 <a href="https://www.cncf.io/projects/werf/" target="_blank">
                     <img src="/assets/images/cncf-logo.svg" alt="cncf logo">
                     {%- if page.lang == "ru" %}
@@ -10,6 +11,7 @@
                         <div class="footer__block-cncf-text">werf is a Cloud Native Computing Foundation sandbox project</div>
                     {%- endif %}
                 </a>
+                <!-- end-spell-delete -->
             </div>
             <div class="footer__block-flant">
                 {%- if page.lang == "ru" %}

--- a/_includes/_common/guides-landing-tile.html
+++ b/_includes/_common/guides-landing-tile.html
@@ -8,7 +8,9 @@
         </svg>
       </div>
     </div>
+    <!-- spell-delete -->
     {% asset 'landing/{{ framework.name }}.svg' width="129" height="79" class="guides__tile-logo guides__tile-logo--{{ framework.name }}" %}
+    <!-- end-spell-delete -->
     <div class="guides__title-progress">
       {% for folder_page_count in folder_pages %}
         {% if folder_page_count == nil %}

--- a/_includes/_common/guides-landing-tile.html
+++ b/_includes/_common/guides-landing-tile.html
@@ -8,9 +8,9 @@
         </svg>
       </div>
     </div>
-    <!-- spell-delete -->
+    <!-- spell-check-ignore -->
     {% asset 'landing/{{ framework.name }}.svg' width="129" height="79" class="guides__tile-logo guides__tile-logo--{{ framework.name }}" %}
-    <!-- end-spell-delete -->
+    <!-- end-spell-check-ignore -->
     <div class="guides__title-progress">
       {% for folder_page_count in folder_pages %}
         {% if folder_page_count == nil %}

--- a/_includes/_common/topnav.html
+++ b/_includes/_common/topnav.html
@@ -80,7 +80,7 @@
                 {%- endfor %}
                 {%- endfor %}
                 <li class="header__menu-item header__menu-item_parent submenu-parent">
-                    <!-- spell-delete -->
+                    <!-- spell-check-ignore -->
                     <a href="#">
                         {%- if page.lang == "ru" %}
                             Русский
@@ -88,22 +88,22 @@
                             English
                         {%- endif %}
                     </a>
-                    <!-- end-spell-delete -->
+                    <!-- end-spell-check-ignore -->
                     <div class="submenu-container">
                       <ul class="submenu">
                         <li data-proofer-ignore class="submenu-item">
-                            <!-- spell-delete -->
+                            <!-- spell-check-ignore -->
                             <a data-proofer-ignore href="{{ site.site_urls.en }}{{ page.url }}" class="submenu-item-link">
                                 English
                             </a>
-                            <!-- end-spell-delete -->
+                            <!-- end-spell-check-ignore -->
                         </li>
                         <li data-proofer-ignore class="submenu-item">
-                            <!-- spell-delete -->
+                            <!-- spell-check-ignore -->
                             <a data-proofer-ignore href="{{ site.site_urls.ru }}{{ page.url }}" class="submenu-item-link">
                                 Русский
                             </a>
-                            <!-- end-spell-delete -->
+                            <!-- end-spell-check-ignore -->
                         </li>
                       </ul>
                     </div>

--- a/_includes/_common/topnav.html
+++ b/_includes/_common/topnav.html
@@ -80,6 +80,7 @@
                 {%- endfor %}
                 {%- endfor %}
                 <li class="header__menu-item header__menu-item_parent submenu-parent">
+                    <!-- spell-delete -->
                     <a href="#">
                         {%- if page.lang == "ru" %}
                             Русский
@@ -87,17 +88,22 @@
                             English
                         {%- endif %}
                     </a>
+                    <!-- end-spell-delete -->
                     <div class="submenu-container">
                       <ul class="submenu">
                         <li data-proofer-ignore class="submenu-item">
+                            <!-- spell-delete -->
                             <a data-proofer-ignore href="{{ site.site_urls.en }}{{ page.url }}" class="submenu-item-link">
                                 English
                             </a>
+                            <!-- end-spell-delete -->
                         </li>
                         <li data-proofer-ignore class="submenu-item">
+                            <!-- spell-delete -->
                             <a data-proofer-ignore href="{{ site.site_urls.ru }}{{ page.url }}" class="submenu-item-link">
                                 Русский
                             </a>
+                            <!-- end-spell-delete -->
                         </li>
                       </ul>
                     </div>

--- a/_includes/en/guides/200_real_apps/030_assets.md.liquid
+++ b/_includes/en/guides/200_real_apps/030_assets.md.liquid
@@ -32,11 +32,15 @@ You should see the following output:
 
 Go to [http://werf-guide-app.test/image](http://werf-guide-app.test/image) in your browser and click on the _Get image_ button. You should see the following output:
 
+<!-- spell-delete -->
 {% include guides/200_real_apps/030_assets/{{ page.framework_id }}/020_image_first.md.liquid %}
+<!-- end-spell-delete -->
 
 Note which resources were requested and which links were used (the last resource here was retrieved via the Ajax request):
 
+<!-- spell-delete -->
 {% include guides/200_real_apps/030_assets/{{ page.framework_id }}/025_image_second.md.liquid %}
+<!-- end-spell-delete -->
 
 Now our application not only provides an API but boasts a set of tools to manage static and JavaScript files effectively.
 

--- a/_includes/en/guides/200_real_apps/030_assets.md.liquid
+++ b/_includes/en/guides/200_real_apps/030_assets.md.liquid
@@ -32,15 +32,15 @@ You should see the following output:
 
 Go to [http://werf-guide-app.test/image](http://werf-guide-app.test/image) in your browser and click on the _Get image_ button. You should see the following output:
 
-<!-- spell-delete -->
+<!-- spell-check-ignore -->
 {% include guides/200_real_apps/030_assets/{{ page.framework_id }}/020_image_first.md.liquid %}
-<!-- end-spell-delete -->
+<!-- end-spell-check-ignore -->
 
 Note which resources were requested and which links were used (the last resource here was retrieved via the Ajax request):
 
-<!-- spell-delete -->
+<!-- spell-check-ignore -->
 {% include guides/200_real_apps/030_assets/{{ page.framework_id }}/025_image_second.md.liquid %}
-<!-- end-spell-delete -->
+<!-- end-spell-check-ignore -->
 
 Now our application not only provides an API but boasts a set of tools to manage static and JavaScript files effectively.
 

--- a/_includes/ru/guides/200_real_apps/030_assets.md.liquid
+++ b/_includes/ru/guides/200_real_apps/030_assets.md.liquid
@@ -32,11 +32,15 @@ werf converge --repo <ИМЯ ПОЛЬЗОВАТЕЛЯ DOCKER HUB>/werf-guide-app
 
 Откроем в браузере [http://werf-guide-app.test/image](http://werf-guide-app.test/image) и нажмём на кнопку _Get image_. Ожидаемый результат:
 
+<!-- spell-delete -->
 {% include guides/200_real_apps/030_assets/{{ page.framework_id }}/020_image_first.md.liquid %}
+<!-- end-spell-delete -->
 
 Также обратим внимание на то, какие ресурсы были запрошены и по каким ссылкам (последний ресурс здесь получен через Ajax-запрос):
 
+<!-- spell-delete -->
 {% include guides/200_real_apps/030_assets/{{ page.framework_id }}/025_image_second.md.liquid %}
+<!-- end-spell-delete -->
 
 Теперь наше приложение является не просто API, но веб-приложением, которое имеет средства для эффективного менеджмента статических файлов и JavaScript.
 

--- a/_includes/ru/guides/200_real_apps/030_assets.md.liquid
+++ b/_includes/ru/guides/200_real_apps/030_assets.md.liquid
@@ -32,15 +32,15 @@ werf converge --repo <ИМЯ ПОЛЬЗОВАТЕЛЯ DOCKER HUB>/werf-guide-app
 
 Откроем в браузере [http://werf-guide-app.test/image](http://werf-guide-app.test/image) и нажмём на кнопку _Get image_. Ожидаемый результат:
 
-<!-- spell-delete -->
+<!-- spell-check-ignore -->
 {% include guides/200_real_apps/030_assets/{{ page.framework_id }}/020_image_first.md.liquid %}
-<!-- end-spell-delete -->
+<!-- end-spell-check-ignore -->
 
 Также обратим внимание на то, какие ресурсы были запрошены и по каким ссылкам (последний ресурс здесь получен через Ajax-запрос):
 
-<!-- spell-delete -->
+<!-- spell-check-ignore -->
 {% include guides/200_real_apps/030_assets/{{ page.framework_id }}/025_image_second.md.liquid %}
-<!-- end-spell-delete -->
+<!-- end-spell-check-ignore -->
 
 Теперь наше приложение является не просто API, но веб-приложением, которое имеет средства для эффективного менеджмента статических файлов и JavaScript.
 

--- a/_layouts/guides-page-base.html
+++ b/_layouts/guides-page-base.html
@@ -55,14 +55,14 @@ layout: default-guides
                         <a href="{{ prev_url }}" style="visibility: hidden;"></a>
                       {% elsif index_sub <= 0 %}
                         {% if page.lang == 'en' %}
-                          <!-- spell-delete -->
+                          <!-- spell-check-ignore -->
                           <a href="{{ main_path_prev }}" class="guides-post__nav--link">
                             <div class="guides-post__nav-arrow ">
                               <span class="btn__icon--prev arrow-guides"></span>
                             </div>
                             prev
                           </a>
-                          <!-- end-spell-delete -->
+                          <!-- end-spell-check-ignore -->
                         {% else %}
                           <a href="{{ main_path_prev }}" class="guides-post__nav--link">
                             <div class="guides-post__nav-arrow">
@@ -73,14 +73,14 @@ layout: default-guides
                         {% endif %}
                       {% else %}
                         {% if page.lang == 'en' %}
-                        <!-- spell-delete -->
+                        <!-- spell-check-ignore -->
                           <a href="{{ prev_url }}" class="guides-post__nav--link">
                             <div class="guides-post__nav-arrow">
                               <span class="btn__icon--prev arrow-guides"></span>
                             </div>
                             prev
                           </a>
-                          <!-- end-spell-delete -->
+                          <!-- end-spell-check-ignore -->
                         {% else %}
                           <a href="{{ prev_url }}" class="guides-post__nav--link">
                             <div class="guides-post__nav-arrow">

--- a/_layouts/guides-page-base.html
+++ b/_layouts/guides-page-base.html
@@ -55,12 +55,14 @@ layout: default-guides
                         <a href="{{ prev_url }}" style="visibility: hidden;"></a>
                       {% elsif index_sub <= 0 %}
                         {% if page.lang == 'en' %}
+                          <!-- spell-delete -->
                           <a href="{{ main_path_prev }}" class="guides-post__nav--link">
                             <div class="guides-post__nav-arrow ">
                               <span class="btn__icon--prev arrow-guides"></span>
                             </div>
                             prev
                           </a>
+                          <!-- end-spell-delete -->
                         {% else %}
                           <a href="{{ main_path_prev }}" class="guides-post__nav--link">
                             <div class="guides-post__nav-arrow">
@@ -71,12 +73,14 @@ layout: default-guides
                         {% endif %}
                       {% else %}
                         {% if page.lang == 'en' %}
+                        <!-- spell-delete -->
                           <a href="{{ prev_url }}" class="guides-post__nav--link">
                             <div class="guides-post__nav-arrow">
                               <span class="btn__icon--prev arrow-guides"></span>
                             </div>
                             prev
                           </a>
+                          <!-- end-spell-delete -->
                         {% else %}
                           <a href="{{ prev_url }}" class="guides-post__nav--link">
                             <div class="guides-post__nav-arrow">

--- a/pages_en/index.md
+++ b/pages_en/index.md
@@ -25,9 +25,9 @@ sidebar: none
                 </div>
                 <div class="intro-banner__link-cncf">
                     <a href="https://www.cncf.io/projects/werf/" target="_blank">
-                        <!-- spell-delete -->
+                        <!-- spell-check-ignore -->
                         <img src="/assets/images/cncf-logo-small.svg" alt="">
-                        <!-- end-spell-delete -->
+                        <!-- end-spell-check-ignore -->
                         <div class="link-cncf__text">werf is a Cloud Native Computing Foundation<br> sandbox project</div>
                     </a>
                 </div>

--- a/pages_en/index.md
+++ b/pages_en/index.md
@@ -25,7 +25,9 @@ sidebar: none
                 </div>
                 <div class="intro-banner__link-cncf">
                     <a href="https://www.cncf.io/projects/werf/" target="_blank">
+                        <!-- spell-delete -->
                         <img src="/assets/images/cncf-logo-small.svg" alt="">
+                        <!-- end-spell-delete -->
                         <div class="link-cncf__text">werf is a Cloud Native Computing Foundation<br> sandbox project</div>
                     </a>
                 </div>

--- a/pages_ru/index.md
+++ b/pages_ru/index.md
@@ -25,9 +25,9 @@ sidebar: none
                 </div>
                 <div class="intro-banner__link-cncf">
                     <a href="https://www.cncf.io/projects/werf/" target="_blank">
-                        <!-- spell-delete -->
+                        <!-- spell-check-ignore -->
                         <img src="/assets/images/cncf-logo-small.svg" alt="">
-                        <!-- end-spell-delete -->
+                        <!-- end-spell-check-ignore -->
                         <div class="link-cncf__text">werf — проект категории sandbox <br>в Cloud Native Computing Foundation</div>
                     </a>
                 </div>

--- a/pages_ru/index.md
+++ b/pages_ru/index.md
@@ -25,7 +25,9 @@ sidebar: none
                 </div>
                 <div class="intro-banner__link-cncf">
                     <a href="https://www.cncf.io/projects/werf/" target="_blank">
+                        <!-- spell-delete -->
                         <img src="/assets/images/cncf-logo-small.svg" alt="">
+                        <!-- end-spell-delete -->
                         <div class="link-cncf__text">werf — проект категории sandbox <br>в Cloud Native Computing Foundation</div>
                     </a>
                 </div>

--- a/scripts/docs/spelling/internal/container_spell_check.sh
+++ b/scripts/docs/spelling/internal/container_spell_check.sh
@@ -29,7 +29,7 @@ echo "Checking $arg_site_lang docs..."
 
 if [ -n "$2" ]; then
   if [ -n "$3" ]; then
-    python3 clear_html_from_code.py $arg_target_page | html2text -utf8 | sed '/^$/d'
+    python3 clear_html_from_code.py $arg_target_page | sed '/<!-- spell-delete -->/,/<!-- end-spell-delete -->/d' | html2text -utf8 | sed '/^$/d'
   else
     check=1
     if test -f "filesignore"; then
@@ -43,7 +43,7 @@ if [ -n "$2" ]; then
 __EOF__
       if [ "$check" -eq 1 ]; then
         echo "Checking $arg_target_page..."
-        python3 clear_html_from_code.py $arg_target_page | html2text -utf8 | sed '/^$/d' | hunspell -d $language -l
+        python3 clear_html_from_code.py $arg_target_page | sed '/<!-- spell-delete -->/,/<!-- end-spell-delete -->/d' | html2text -utf8 | sed '/^$/d' | hunspell -d $language -l
       else
         echo "Ignoring $arg_target_page..."
       fi
@@ -65,7 +65,7 @@ __EOF__
       if [ "$check" -eq 1 ]; then
         echo "$str"
         echo "$indicator: checking $file..."
-        python3 clear_html_from_code.py $file | html2text -utf8 | sed '/^$/d' | hunspell -d $language -l
+        python3 clear_html_from_code.py $file | sed '/<!-- spell-delete -->/,/<!-- end-spell-delete -->/d' | html2text -utf8 | sed '/^$/d' | hunspell -d $language -l
       else
         echo "$str"
         echo "Ignoring $indicator: $file..."

--- a/scripts/docs/spelling/internal/container_spell_check.sh
+++ b/scripts/docs/spelling/internal/container_spell_check.sh
@@ -29,7 +29,7 @@ echo "Checking $arg_site_lang docs..."
 
 if [ -n "$2" ]; then
   if [ -n "$3" ]; then
-    python3 clear_html_from_code.py $arg_target_page | sed '/<!-- spell-delete -->/,/<!-- end-spell-delete -->/d' | html2text -utf8 | sed '/^$/d'
+    python3 clear_html_from_code.py $arg_target_page | sed '/<!-- spell-check-ignore -->/,/<!-- end-spell-check-ignore -->/d' | html2text -utf8 | sed '/^$/d'
   else
     check=1
     if test -f "filesignore"; then
@@ -43,7 +43,7 @@ if [ -n "$2" ]; then
 __EOF__
       if [ "$check" -eq 1 ]; then
         echo "Checking $arg_target_page..."
-        python3 clear_html_from_code.py $arg_target_page | sed '/<!-- spell-delete -->/,/<!-- end-spell-delete -->/d' | html2text -utf8 | sed '/^$/d' | hunspell -d $language -l
+        python3 clear_html_from_code.py $arg_target_page | sed '/<!-- spell-check-ignore -->/,/<!-- end-spell-check-ignore -->/d' | html2text -utf8 | sed '/^$/d' | hunspell -d $language -l
       else
         echo "Ignoring $arg_target_page..."
       fi
@@ -65,7 +65,7 @@ __EOF__
       if [ "$check" -eq 1 ]; then
         echo "$str"
         echo "$indicator: checking $file..."
-        python3 clear_html_from_code.py $file | sed '/<!-- spell-delete -->/,/<!-- end-spell-delete -->/d' | html2text -utf8 | sed '/^$/d' | hunspell -d $language -l
+        python3 clear_html_from_code.py $file | sed '/<!-- spell-check-ignore -->/,/<!-- end-spell-check-ignore -->/d' | html2text -utf8 | sed '/^$/d' | hunspell -d $language -l
       else
         echo "$str"
         echo "Ignoring $indicator: $file..."


### PR DESCRIPTION
* Added functionality for removing parts of the page from the final HTML. The necessary parts are highlighted with comments. For example:
  ```html
            <div class="footer__block-cncf">
                <!-- spell-check-ignore -->
                <a href="https://www.cncf.io/projects/werf/" target="_blank">
                    <img src="/assets/images/cncf-logo.svg" alt="cncf logo">
                    {%- if page.lang == "ru" %}
                        <div class="footer__block-cncf-text">werf — проект категории sandbox в&nbsp;Cloud Native Computing Foundation</div>
                    {%- else %}
                        <div class="footer__block-cncf-text">werf is a Cloud Native Computing Foundation sandbox project</div>
                    {%- endif %}
                </a>
                <!-- end-spell-check-ignore -->
            </div>
  ```
* Some parts of the pages with spelling errors have already been highlighted with comments.