### PR TITLE
Delete the configurator tabs from the sitemap

### DIFF
--- a/sitemap-site.xml
+++ b/sitemap-site.xml
@@ -10,6 +10,9 @@ search: exclude
 
     {%- assign pages_in_main_lang=site.pages | where: "lang", site.site_lang | where: "sitemap_include", true | where_exp: "page", "page.layout != 'guides-wip'" | where_exp: "page", "page.layout != 'guides-development'" %}
     {%- for page in pages_in_main_lang %}
+        {% if page.url contains "configurator/tabs/" %}
+            {% continue %}
+        {% endif %}
     <url>
         <loc>{{ page.url | absolute_url }}</loc>
         <xhtml:link rel="alternate" hreflang="ru" href="{{ site.site_urls.ru }}{{ page.url | relative_url }}" />


### PR DESCRIPTION
The configurator tabs (`configurator/tabs/*`) have been removed from the sitemap.