### PR TITLE
[spell-check] Refactor GitHub actions and exit codes

### DIFF
--- a/.github/workflows/content_validation.yml
+++ b/.github/workflows/content_validation.yml
@@ -43,7 +43,7 @@ jobs:
         env:
           WERF_REPO: "ghcr.io/${{ github.repository_owner }}/werfio"
 
-  spell_check:
+  spell_check_ru:
     runs-on: ubuntu-latest-4-cores
     timeout-minutes: 60
     steps:
@@ -68,6 +68,35 @@ jobs:
       - name: Spell check
         run: |
           source "$(werf ci-env github --as-file)"
-          task -o group -p site:run-spell-check
+          task -o group -p site:run-spell-check:ru
+        env:
+          WERF_REPO: "ghcr.io/${{ github.repository_owner }}/werfio"
+
+  spell_check_en:
+    runs-on: ubuntu-latest-4-cores
+    timeout-minutes: 60
+    steps:
+      - name: Install werf
+        uses: werf/actions/install@v1.2
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to GitHub container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Spell check
+        run: |
+          source "$(werf ci-env github --as-file)"
+          task -o group -p site:run-spell-check:en
         env:
           WERF_REPO: "ghcr.io/${{ github.repository_owner }}/werfio"

--- a/scripts/docs/spelling/dictionaries/dev_OPS.dic
+++ b/scripts/docs/spelling/dictionaries/dev_OPS.dic
@@ -1,4 +1,4 @@
-449
+450
 1GB
 2GB
 5XX
@@ -214,6 +214,7 @@ TBH
 templating
 terminationGracePeriodSeconds
 THENEWSTACK
+Thev1
 Thymeleaf
 TLF
 TLS

--- a/scripts/docs/spelling/internal/container_spell_check.sh
+++ b/scripts/docs/spelling/internal/container_spell_check.sh
@@ -43,7 +43,10 @@ if [ -n "$2" ]; then
 __EOF__
       if [ "$check" -eq 1 ]; then
         echo "Checking $arg_target_page..."
-        python3 clear_html_from_code.py $arg_target_page | sed '/<!-- spell-check-ignore -->/,/<!-- end-spell-check-ignore -->/d' | html2text -utf8 | sed '/^$/d' | hunspell -d $language -l
+        result=$(python3 clear_html_from_code.py $file | sed '/<!-- spell-check-ignore -->/,/<!-- end-spell-check-ignore -->/d' | html2text -utf8 | sed '/^$/d' | hunspell -d $language -l)
+        if [ -n "$result" ]; then
+          echo $result | sed 's/\s\+/\n/g'
+        fi
       else
         echo "Ignoring $arg_target_page..."
       fi
@@ -63,11 +66,13 @@ else
   $(cat ./filesignore)
 __EOF__
       if [ "$check" -eq 1 ]; then
-        echo "$str"
-        echo "$indicator: checking $file..."
-        python3 clear_html_from_code.py $file | sed '/<!-- spell-check-ignore -->/,/<!-- end-spell-check-ignore -->/d' | html2text -utf8 | sed '/^$/d' | hunspell -d $language -l
+        result=$(python3 clear_html_from_code.py $file | sed '/<!-- spell-check-ignore -->/,/<!-- end-spell-check-ignore -->/d' | html2text -utf8 | sed '/^$/d' | hunspell -d $language -l)
+        if [ -n "$result" ]; then
+          echo $str
+          echo "$indicator: checking $file..."
+          echo $result | sed 's/\s\+/\n/g'
+        fi
       else
-        echo "$str"
         echo "Ignoring $indicator: $file..."
       fi
     fi

--- a/scripts/docs/spelling/internal/container_spell_check.sh
+++ b/scripts/docs/spelling/internal/container_spell_check.sh
@@ -4,6 +4,7 @@ set -e
 
 arg_site_lang="${1:?ERROR: Site language \'en\' or \'ru\' should be specified as the first argument.}"
 str=$'\n'
+ex_result=0
 
 if [[ "$arg_site_lang" == "en" ]]; then
   language="en_US,dev_OPS"
@@ -68,6 +69,8 @@ __EOF__
       if [ "$check" -eq 1 ]; then
         result=$(python3 clear_html_from_code.py $file | sed '/<!-- spell-check-ignore -->/,/<!-- end-spell-check-ignore -->/d' | html2text -utf8 | sed '/^$/d' | hunspell -d $language -l)
         if [ -n "$result" ]; then
+          unset ex_result
+          ex_result=1
           echo $str
           echo "$indicator: checking $file..."
           echo $result | sed 's/\s\+/\n/g'
@@ -77,4 +80,7 @@ __EOF__
       fi
     fi
   done
+  if [ "$ex_result" -eq 1 ]; then
+    exit 1
+  fi
 fi

--- a/scripts/docs/spelling/wordlist
+++ b/scripts/docs/spelling/wordlist
@@ -66,7 +66,6 @@ DevOpsConf
 Django
 Dockerfile
 Dockerfiles
-Thev1
 dockerignore
 dockersamples
 DSL
@@ -214,6 +213,7 @@ TBH
 templating
 terminationGracePeriodSeconds
 THENEWSTACK
+Thev1
 Thymeleaf
 TLF
 TLS


### PR DESCRIPTION
1. The spell check is divided into two separate tests: Ru and En.
2. Added exit codes for each test.
3. Empty messages about files in which nothing was found were removed from the exhaust.
4. The labels about ignoring files are left to be aware of how the ignoring mechanism works.