### PR TITLE
ci: Trigger Deploy on workflow_dispatch events

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,7 @@ on:
       - main
   pull_request:
     types: [ labeled, synchronize ]
+  workflow_dispatch:
 
 env:
   WERF_ENV: "production"


### PR DESCRIPTION
Trigger Deploy on the `workflow_dispatch` event. 
Deploy will be triggered when a new [werf](https://github.com/werf/werf/) release is out.