### PR TITLE
 fix(guides): fix the Prepare environment link

### DIFF
--- a/_data/en/guides/ask_and_star_buttons.yaml
+++ b/_data/en/guides/ask_and_star_buttons.yaml
@@ -11,7 +11,7 @@
   icon_class: sidebar__btn-icon_github
 
 # Preparing the environment
-- url: https://werf.io/guides/rails/100_basic/20_cluster.html
+- url: /guides/{framework}/100_basic/20_cluster.html
   title: Go to &quot;Prepare the environment&quot; section
   text: Prepare/fix the environment
   class: sidebar-button--environment

--- a/_includes/_layouts/guides/ask_and_star_buttons.html
+++ b/_includes/_layouts/guides/ask_and_star_buttons.html
@@ -1,6 +1,11 @@
 <div class="sidebar__btns">
   {%- for btn in site.data.guides.ask_and_star_buttons %}
-  <a href="{{ btn.url }}" target="_blank" class="sidebar__btn {%- if btn.class %} {{ btn.class }}{%- endif %}" title="{{ btn.title }}">
+    {% assign btn_url = btn.url | replace: "{framework}", page.framework_id %}
+    {% assign btn_url_first = btn_url | truncate : 1, '' %}
+    {% if btn_url_first == '/' %}
+      {% assign btn_internal = true %}
+    {% endif %}
+  <a href="{{ btn_url }}" {%- if btn_internal != true %}target="_blank"{%- endif %} class="sidebar__btn {%- if btn.class %} {{ btn.class }}{%- endif %}" title="{{ btn.title }}">
     <span class="sidebar__btn-icon {{ btn.icon_class }}"></span>
     {{ btn.text }}
   </a>


### PR DESCRIPTION
This PR fixes two current issues with the red button ("Prepare/fix the environment") at the Kubernetes guides' sidebar:

1. It was static and always led to the Ruby/Rails article.
2. It was external and always opened in a new tab/window.