### PR TITLE
Fixes: manifests in guides, navigation and local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ configurator-data.json
 configurator-options-list.json
 spell_log_ru
 spell_log_en
+assets/images/plantuml_cache

--- a/_layouts/guides-page-base.html
+++ b/_layouts/guides-page-base.html
@@ -95,8 +95,6 @@ layout: default-guides
                     <div class="guides-post__nav--next">
                       {% if index_sub >= subsection_size and sections.f[index_next] == nil %}
                         <a href="{{ next_url }}" style="visibility: hidden;"></a>
-                      {% elsif index_sub >= subsection_size and sections.f[index_next].external == true %}
-                        <a href="{{ next_url }}" style="visibility: hidden;"></a>
                       {% elsif index_sub >= subsection_size and folder_page == nil %}
                         <a href="{{ next_url }}" style="visibility: hidden;"></a>
                       {% elsif index_sub >= subsection_size and folder_page != nil %}

--- a/_layouts/guides-page-base.html
+++ b/_layouts/guides-page-base.html
@@ -95,6 +95,8 @@ layout: default-guides
                     <div class="guides-post__nav--next">
                       {% if index_sub >= subsection_size and sections.f[index_next] == nil %}
                         <a href="{{ next_url }}" style="visibility: hidden;"></a>
+                      {% elsif index_sub >= subsection_size and sections.f[index_next].external == true %}
+                        <a href="{{ next_url }}" style="visibility: hidden;"></a>
                       {% elsif index_sub >= subsection_size and folder_page == nil %}
                         <a href="{{ next_url }}" style="visibility: hidden;"></a>
                       {% elsif index_sub >= subsection_size and folder_page != nil %}

--- a/examples/configurator/local-dev/.helm/charts/backend/templates/job-db-migrate.yaml
+++ b/examples/configurator/local-dev/.helm/charts/backend/templates/job-db-migrate.yaml
@@ -9,6 +9,8 @@ spec:
   template:
     spec:
       restartPolicy: Never
+      imagePullSecrets:
+      - name: registrysecret
       containers:
       - name: migrate-db
         image: {{ $.Values.werf.image.backend }}

--- a/examples/django/030_assets/.werf/nginx.conf
+++ b/examples/django/030_assets/.werf/nginx.conf
@@ -56,8 +56,8 @@ http {
       try_files $uri =404;
     }
 
-    # [<en>] All requests, except for asset requests, are sent to the Spring Boot backend.
-    # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на Spring Boot бэкенд.
+    # [<en>] All requests, except for asset requests, are sent to the backend.
+    # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на бэкенд.
     location / {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Real-IP $remote_addr;

--- a/examples/django/040_db/.helm/templates/job-db-setup-and-migrate.yaml
+++ b/examples/django/040_db/.helm/templates/job-db-setup-and-migrate.yaml
@@ -11,6 +11,8 @@ spec:
   template:
     spec:
       restartPolicy: Never
+      imagePullSecrets:
+      - name: registrysecret
       initContainers:
       - name: waiting-mysql
         image: alpine:3.6

--- a/examples/django/040_db/.werf/nginx.conf
+++ b/examples/django/040_db/.werf/nginx.conf
@@ -56,8 +56,8 @@ http {
       try_files $uri =404;
     }
 
-    # [<en>] All requests, except for asset requests, are sent to the Spring Boot backend.
-    # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на Spring Boot бэкенд.
+    # [<en>] All requests, except for asset requests, are sent to the backend.
+    # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на бэкенд.
     location / {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Real-IP $remote_addr;

--- a/examples/django/050_s3/.helm/templates/job-db-setup-and-migrate.yaml
+++ b/examples/django/050_s3/.helm/templates/job-db-setup-and-migrate.yaml
@@ -11,6 +11,8 @@ spec:
   template:
     spec:
       restartPolicy: Never
+      imagePullSecrets:
+      - name: registrysecret
       initContainers:
       - name: waiting-mysql
         image: alpine:3.6

--- a/examples/django/050_s3/.werf/nginx.conf
+++ b/examples/django/050_s3/.werf/nginx.conf
@@ -56,8 +56,8 @@ http {
       try_files $uri =404;
     }
 
-    # [<en>] All requests, except for asset requests, are sent to the Spring Boot backend.
-    # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на Spring Boot бэкенд.
+    # [<en>] All requests, except for asset requests, are sent to the backend.
+    # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на бэкенд.
     location / {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Real-IP $remote_addr;

--- a/examples/django/080_configuration/.helm/templates/configmap-nginx.yaml
+++ b/examples/django/080_configuration/.helm/templates/configmap-nginx.yaml
@@ -62,8 +62,8 @@ data:
           try_files $uri =404;
         }
 
-        # [<en>] All requests, except for asset requests, are sent to the Spring Boot backend.
-        # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на Spring Boot бэкенд.
+        # [<en>] All requests, except for asset requests, are sent to the backend.
+        # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на бэкенд.
         location / {
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
           proxy_set_header X-Real-IP $remote_addr;

--- a/examples/django/080_configuration/.helm/templates/database.yaml
+++ b/examples/django/080_configuration/.helm/templates/database.yaml
@@ -16,7 +16,6 @@ spec:
       containers:
       - name: mysql
         image: mysql:9.1
-        args: ["--default-authentication-plugin=mysql_native_password"]
         ports:
           - containerPort: 3306
         envFrom:

--- a/examples/django/080_configuration/.helm/templates/job-db-setup-and-migrate.yaml
+++ b/examples/django/080_configuration/.helm/templates/job-db-setup-and-migrate.yaml
@@ -11,6 +11,8 @@ spec:
   template:
     spec:
       restartPolicy: Never
+      imagePullSecrets:
+      - name: registrysecret
       initContainers:
       - name: waiting-mysql
         image: alpine:3.6

--- a/examples/golang/030_assets/.werf/nginx.conf
+++ b/examples/golang/030_assets/.werf/nginx.conf
@@ -56,8 +56,8 @@ http {
       try_files $uri =404;
     }
 
-    # [<en>] All requests, except for asset requests, are sent to the Spring Boot backend.
-    # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на Spring Boot бэкенд.
+    # [<en>] All requests, except for asset requests, are sent to the backend.
+    # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на бэкенд.
     location / {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Real-IP $remote_addr;

--- a/examples/golang/040_db/.helm/templates/database.yaml
+++ b/examples/golang/040_db/.helm/templates/database.yaml
@@ -15,7 +15,6 @@ spec:
       containers:
       - name: mysql
         image: mysql:9.1
-        args: ["--mysql-native-password=ON"]
         ports:
         - containerPort: 3306
         env:

--- a/examples/golang/040_db/.helm/templates/job-db-setup-and-migrate.yaml
+++ b/examples/golang/040_db/.helm/templates/job-db-setup-and-migrate.yaml
@@ -11,6 +11,8 @@ spec:
   template:
     spec:
       restartPolicy: Never
+      imagePullSecrets:
+      - name: registrysecret
       initContainers:
       - name: waiting-mysql
         image: alpine:3.6

--- a/examples/golang/040_db/.werf/nginx.conf
+++ b/examples/golang/040_db/.werf/nginx.conf
@@ -56,8 +56,8 @@ http {
       try_files $uri =404;
     }
 
-    # [<en>] All requests, except for asset requests, are sent to the Spring Boot backend.
-    # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на Spring Boot бэкенд.
+    # [<en>] All requests, except for asset requests, are sent to the backend.
+    # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на бэкенд.
     location / {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Real-IP $remote_addr;

--- a/examples/golang/050_s3/.helm/templates/database.yaml
+++ b/examples/golang/050_s3/.helm/templates/database.yaml
@@ -15,7 +15,6 @@ spec:
       containers:
       - name: mysql
         image: mysql:9.1
-        args: ["--mysql-native-password=ON"]
         ports:
         - containerPort: 3306
         env:

--- a/examples/golang/050_s3/.helm/templates/job-db-setup-and-migrate.yaml
+++ b/examples/golang/050_s3/.helm/templates/job-db-setup-and-migrate.yaml
@@ -11,6 +11,8 @@ spec:
   template:
     spec:
       restartPolicy: Never
+      imagePullSecrets:
+      - name: registrysecret
       initContainers:
       - name: waiting-mysql
         image: alpine:3.6

--- a/examples/golang/050_s3/.werf/nginx.conf
+++ b/examples/golang/050_s3/.werf/nginx.conf
@@ -56,8 +56,8 @@ http {
       try_files $uri =404;
     }
 
-    # [<en>] All requests, except for asset requests, are sent to the Spring Boot backend.
-    # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на Spring Boot бэкенд.
+    # [<en>] All requests, except for asset requests, are sent to the backend.
+    # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на бэкенд.
     location / {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Real-IP $remote_addr;

--- a/examples/golang/080_configuration/.helm/templates/configmap-nginx.yaml
+++ b/examples/golang/080_configuration/.helm/templates/configmap-nginx.yaml
@@ -62,8 +62,8 @@ data:
           try_files $uri =404;
         }
 
-        # [<en>] All requests, except for asset requests, are sent to the Spring Boot backend.
-        # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на Spring Boot бэкенд.
+        # [<en>] All requests, except for asset requests, are sent to the backend.
+        # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на бэкенд.
         location / {
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
           proxy_set_header X-Real-IP $remote_addr;

--- a/examples/golang/080_configuration/.helm/templates/database.yaml
+++ b/examples/golang/080_configuration/.helm/templates/database.yaml
@@ -15,7 +15,6 @@ spec:
       containers:
       - name: mysql
         image: mysql:9.1
-        args: ["--mysql-native-password=ON"]
         ports:
         - containerPort: 3306
         volumeMounts:

--- a/examples/golang/080_configuration/.helm/templates/job-db-setup-and-migrate.yaml
+++ b/examples/golang/080_configuration/.helm/templates/job-db-setup-and-migrate.yaml
@@ -11,6 +11,8 @@ spec:
   template:
     spec:
       restartPolicy: Never
+      imagePullSecrets:
+      - name: registrysecret
       initContainers:
       - name: waiting-mysql
         image: alpine:3.6

--- a/examples/java_springboot/030_assets/.werf/nginx.conf
+++ b/examples/java_springboot/030_assets/.werf/nginx.conf
@@ -56,8 +56,8 @@ http {
       try_files $uri =404;
     }
 
-    # [<en>] All requests, except for asset requests, are sent to the Spring Boot backend.
-    # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на Spring Boot бэкенд.
+    # [<en>] All requests, except for asset requests, are sent to the backend.
+    # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на бэкенд.
     location / {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Real-IP $remote_addr;

--- a/examples/java_springboot/040_db/.helm/templates/database.yaml
+++ b/examples/java_springboot/040_db/.helm/templates/database.yaml
@@ -15,7 +15,6 @@ spec:
       containers:
       - name: mysql
         image: mysql:9.1
-        args: ["--mysql-native-password=ON"]
         ports:
         - containerPort: 3306
         env:

--- a/examples/java_springboot/040_db/.werf/nginx.conf
+++ b/examples/java_springboot/040_db/.werf/nginx.conf
@@ -59,8 +59,8 @@ http {
       try_files $uri =404;
     }
 
-    # [<en>] All requests, except for asset requests, are routed to the Node.js backend.
-    # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на Node.js-бэкенд.
+    # [<en>] All requests, except for asset requests, are routed to the backend.
+    # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на бэкенд.
     location / {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Real-IP $remote_addr;

--- a/examples/java_springboot/050_s3/.helm/templates/database.yaml
+++ b/examples/java_springboot/050_s3/.helm/templates/database.yaml
@@ -15,7 +15,6 @@ spec:
       containers:
       - name: mysql
         image: mysql:9.1
-        args: ["--mysql-native-password=ON"]
         ports:
         - containerPort: 3306
         env:

--- a/examples/java_springboot/050_s3/.werf/nginx.conf
+++ b/examples/java_springboot/050_s3/.werf/nginx.conf
@@ -59,8 +59,8 @@ http {
       try_files $uri =404;
     }
 
-    # [<en>] All requests, except for asset requests, are routed to the Node.js backend.
-    # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на Node.js-бэкенд.
+    # [<en>] All requests, except for asset requests, are routed to the backend.
+    # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на бэкенд.
     location / {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Real-IP $remote_addr;

--- a/examples/java_springboot/080_configuration/.helm/templates/configmap-nginx.yaml
+++ b/examples/java_springboot/080_configuration/.helm/templates/configmap-nginx.yaml
@@ -65,8 +65,8 @@ data:
           try_files $uri =404;
         }
 
-        # [<en>] All requests, except for asset requests, are routed to the Node.js backend.
-        # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на Node.js-бэкенд.
+        # [<en>] All requests, except for asset requests, are routed to the backend.
+        # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на бэкенд.
         location / {
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
           proxy_set_header X-Real-IP $remote_addr;

--- a/examples/java_springboot/080_configuration/.helm/templates/database.yaml
+++ b/examples/java_springboot/080_configuration/.helm/templates/database.yaml
@@ -15,7 +15,6 @@ spec:
       containers:
       - name: mysql
         image: mysql:9.1
-        args: ["--mysql-native-password=ON"]
         ports:
         - containerPort: 3306
         volumeMounts:

--- a/examples/java_springboot/080_configuration/.werf/nginx.conf
+++ b/examples/java_springboot/080_configuration/.werf/nginx.conf
@@ -59,8 +59,8 @@ http {
       try_files $uri =404;
     }
 
-    # [<en>] All requests, except for asset requests, are routed to the Node.js backend.
-    # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на Node.js-бэкенд.
+    # [<en>] All requests, except for asset requests, are routed to the backend.
+    # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на бэкенд.
     location / {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Real-IP $remote_addr;

--- a/examples/laravel/040_db/.helm/templates/database.yaml
+++ b/examples/laravel/040_db/.helm/templates/database.yaml
@@ -15,7 +15,6 @@ spec:
       containers:
       - name: mysql
         image: mysql:9.1
-        args: ["--mysql-native-password=ON"]
         ports:
         - containerPort: 3306
         env:

--- a/examples/laravel/050_s3/.helm/templates/database.yaml
+++ b/examples/laravel/050_s3/.helm/templates/database.yaml
@@ -15,7 +15,6 @@ spec:
       containers:
       - name: mysql
         image: mysql:9.1
-        args: ["--mysql-native-password=ON"]
         ports:
         - containerPort: 3306
         env:

--- a/examples/laravel/080_configuration/.helm/templates/configmap-nginx.yaml
+++ b/examples/laravel/080_configuration/.helm/templates/configmap-nginx.yaml
@@ -54,7 +54,7 @@ data:
         location = /favicon.ico { access_log off; log_not_found off; }
         location = /robots.txt  { access_log off; log_not_found off; }
 
-        # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на php-fpm-бэкенд.
+        # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на бэкенд.
         location ~ \.php$ {
             fastcgi_pass unix:/var/run/php/php-fpm.sock;
             fastcgi_param DOCUMENT_ROOT   /app/public;

--- a/examples/laravel/080_configuration/.helm/templates/database.yaml
+++ b/examples/laravel/080_configuration/.helm/templates/database.yaml
@@ -17,7 +17,6 @@ spec:
       containers:
       - name: mysql
         image: mysql:9.1
-        args: ["--mysql-native-password=ON"]
         ports:
         - containerPort: 3306
         envFrom:

--- a/examples/nodejs/030_assets/.werf/nginx.conf
+++ b/examples/nodejs/030_assets/.werf/nginx.conf
@@ -59,8 +59,8 @@ http {
       try_files $uri =404;
     }
 
-    # [<en>] All requests, except for asset requests, are routed to the Node.js backend.
-    # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на Node.js-бэкенд.
+    # [<en>] All requests, except for asset requests, are routed to the backend.
+    # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на бэкенд.
     location / {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Real-IP $remote_addr;

--- a/examples/nodejs/040_db/.werf/nginx.conf
+++ b/examples/nodejs/040_db/.werf/nginx.conf
@@ -59,8 +59,8 @@ http {
       try_files $uri =404;
     }
 
-    # [<en>] All requests, except for asset requests, are routed to the Node.js backend.
-    # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на Node.js-бэкенд.
+    # [<en>] All requests, except for asset requests, are routed to the backend.
+    # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на бэкенд.
     location / {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Real-IP $remote_addr;

--- a/examples/nodejs/050_s3/.werf/nginx.conf
+++ b/examples/nodejs/050_s3/.werf/nginx.conf
@@ -59,8 +59,8 @@ http {
       try_files $uri =404;
     }
 
-    # [<en>] All requests, except for asset requests, are routed to the Node.js backend.
-    # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на Node.js-бэкенд.
+    # [<en>] All requests, except for asset requests, are routed to the backend.
+    # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на бэкенд.
     location / {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Real-IP $remote_addr;

--- a/examples/nodejs/080_configuration/.helm/templates/configmap-nginx.yaml
+++ b/examples/nodejs/080_configuration/.helm/templates/configmap-nginx.yaml
@@ -65,8 +65,8 @@ data:
           try_files $uri =404;
         }
 
-        # [<en>] All requests, except for asset requests, are routed to the Node.js backend.
-        # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на Node.js-бэкенд.
+        # [<en>] All requests, except for asset requests, are routed to the backend.
+        # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на бэкенд.
         location / {
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
           proxy_set_header X-Real-IP $remote_addr;

--- a/examples/rails/030_assets/.werf/nginx.conf
+++ b/examples/rails/030_assets/.werf/nginx.conf
@@ -59,8 +59,8 @@ http {
       try_files $uri =404;
     }
 
-    # [<en>] All requests, except for asset requests, are routed to the Puma backend.
-    # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на Puma-бэкенд.
+    # [<en>] All requests, except for asset requests, are routed to the backend.
+    # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на бэкенд.
     location / {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Real-IP $remote_addr;

--- a/examples/rails/040_db/.werf/nginx.conf
+++ b/examples/rails/040_db/.werf/nginx.conf
@@ -53,7 +53,7 @@ http {
       try_files $uri =404;
     }
 
-    # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на Puma-бэкенд.
+    # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на бэкенд.
     location / {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Real-IP $remote_addr;

--- a/examples/rails/050_s3/.werf/nginx.conf
+++ b/examples/rails/050_s3/.werf/nginx.conf
@@ -53,7 +53,7 @@ http {
       try_files $uri =404;
     }
 
-    # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на Puma-бэкенд.
+    # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на бэкенд.
     location / {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Real-IP $remote_addr;

--- a/examples/rails/080_configuration/.helm/templates/configmap-nginx.yaml
+++ b/examples/rails/080_configuration/.helm/templates/configmap-nginx.yaml
@@ -65,8 +65,8 @@ data:
           try_files $uri =404;
         }
 
-        # [<en>] All requests, except for asset ones, are routed to the Puma backend.
-        # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на Puma-бэкенд.
+        # [<en>] All requests, except for asset ones, are routed to the backend.
+        # [<ru>] Все запросы, кроме запросов на получение ассетов, отправляются на бэкенд.
         location / {
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
           proxy_set_header X-Real-IP $remote_addr;

--- a/werf.yaml
+++ b/werf.yaml
@@ -69,7 +69,7 @@ ansible:
       chdir: /artifacts
 ---
 image: configuration_artifacts
-from: golang:1.21
+from: golang:1.24
 fromCacheVersion: {{ $.CacheVersion }}
 git:
   - add: /bin/configurator
@@ -144,7 +144,7 @@ shell:
 {{ end -}}
 
 image: backend-artifact
-from: golang:1.16
+from: golang:1.24
 fromCacheVersion: {{ $.CacheVersion }}
 ansible:
   install:


### PR DESCRIPTION
Hi, and thanks for your project!
While following guides https://werf.io/guides.html I've noticed some inaccuracies. I believe a skilled engineer can overcome this, but it's better to fix.

**Content fixes:**
- in `nginx.conf` I've removed backend specification. For golang comment stated "springboot backend", which is not true. I think, it's easier just to say 'backend' rather than specify in each particular case.
- in `job-db-migrate.yaml` I've added missing directive 'imagePullSecrets'
- in `database.yaml` I've removed arg with mysql-native-password. It was [depricated in mysql 9](https://dev.mysql.com/doc/relnotes/mysql/9.0/en/news-9-0-0.html#mysqld-9-0-0-deprecation-removal)

**Other fixes:**
- I've also bumped version of golang base image to 1.24 because of errors with `werf compose` when trying to fire up site locally.
- and added `assets/images/plantuml_cache` to gitignore, as it seems to contain cache which is not needed.