### PR TITLE
docs(getting-started): add netavark and pasta host prep for werf 3

### DIFF
--- a/bin/configurator/static/_includes/en/configurator/partials/ci/buildah_install.md.liquid
+++ b/bin/configurator/static/_includes/en/configurator/partials/ci/buildah_install.md.liquid
@@ -32,6 +32,8 @@
     Make sure there are no conflicts with other ranges, if any. Changing files may require a reboot. See `man subuid` and `man subgid` for details.
 
 * (Linux 5.12 and below) Install the package that provides the `fuse-overlayfs` utility.
+
+* (For werf 3 and later) Install the packages providing the `netavark` and `pasta` binaries (usually `netavark` and `passt`). werf looks for `netavark` only in the Podman helper binaries directories (e.g. `/usr/lib/podman` or `/usr/libexec/podman`); distribution packages install it there. If your distribution has no netavark package, place a [release binary](https://github.com/containers/netavark/releases) in `/usr/local/lib/podman/`.
   {% if include.type == "github" %}
 
 * Make sure that the `/home/github-runner/.local/share/containers` path is created and the `github-runner` user has read and write access.

--- a/bin/configurator/static/_includes/en/configurator/partials/dev/buildah_install.md.liquid
+++ b/bin/configurator/static/_includes/en/configurator/partials/dev/buildah_install.md.liquid
@@ -28,6 +28,8 @@
 
 * (For Linux 5.12 and below) Install the package that provides the `fuse-overlayfs` utility.
 
+* (For werf 3 and later) Install the packages providing the `netavark` and `pasta` binaries (usually `netavark` and `passt`). werf looks for `netavark` only in the Podman helper binaries directories (e.g. `/usr/lib/podman` or `/usr/libexec/podman`); distribution packages install it there. If your distribution has no netavark package, place a [release binary](https://github.com/containers/netavark/releases) in `/usr/local/lib/podman/`.
+
 * Make sure that the `/home/<current user>/.local/share/containers` path has been created and the current user has read and write access to it.
 
 * The `sysctl -ne kernel.unprivileged_userns_clone` command should NOT return `0`, otherwise run `echo 'kernel.unprivileged_userns_clone = 1' | sudo tee -a /etc/sysctl.conf && sudo sysctl -p`.

--- a/bin/configurator/static/_includes/en/configurator/tab/ci/other-ci-cd-system/simple/host-runner/linux/buildah/infra.md.liquid
+++ b/bin/configurator/static/_includes/en/configurator/tab/ci/other-ci-cd-system/simple/host-runner/linux/buildah/infra.md.liquid
@@ -44,6 +44,8 @@ To install Buildah, do the following on the host for running CI jobs:
 
 * (For Linux 5.12 and below) Install the package that provides the `fuse-overlayfs` utility.
 
+* (For werf 3 and later) Install the packages providing the `netavark` and `pasta` binaries (usually `netavark` and `passt`). werf looks for `netavark` only in the Podman helper binaries directories (e.g. `/usr/lib/podman` or `/usr/libexec/podman`); distribution packages install it there. If your distribution has no netavark package, place a [release binary](https://github.com/containers/netavark/releases) in `/usr/local/lib/podman/`.
+
 * Make sure the `/home/<user to run CI jobs>/.local/share/containers` path is created and the user to run CI jobs has read and write access.
 
 * The `sysctl -ne kernel.unprivileged_userns_clone` command should NOT return `0`, otherwise run `echo 'kernel.unprivileged_userns_clone = 1' | sudo tee -a /etc/sysctl.conf && sudo sysctl -p`.

--- a/bin/configurator/static/_includes/ru/configurator/partials/ci/buildah_install.md.liquid
+++ b/bin/configurator/static/_includes/ru/configurator/partials/ci/buildah_install.md.liquid
@@ -31,6 +31,8 @@
     Избегайте коллизий с другими диапазонами, если они имеются. Изменение файлов может потребовать перезагрузки. Подробнее в `man subuid` и `man subgid`.
 
 * (Для Linux 5.12 и ниже) Установите пакет, предоставляющий программу `fuse-overlayfs`.
+
+* (Для werf 3 и новее) Установите пакеты, предоставляющие бинарные файлы `netavark` и `pasta` (обычно это пакеты `netavark` и `passt`). werf ищет `netavark` только в каталогах вспомогательных бинарных файлов Podman (например, `/usr/lib/podman` или `/usr/libexec/podman`); дистрибутивные пакеты устанавливают его туда. Если в вашем дистрибутиве нет пакета netavark, поместите [бинарный файл из релиза](https://github.com/containers/netavark/releases) в `/usr/local/lib/podman/`.
   {% if include.type == "github" %}
 
 * Убедитесь, что путь `/home/github-runner/.local/share/containers` создан, и пользователь `github-runner` имеет доступ на чтение и запись.

--- a/bin/configurator/static/_includes/ru/configurator/partials/dev/buildah_install.md.liquid
+++ b/bin/configurator/static/_includes/ru/configurator/partials/dev/buildah_install.md.liquid
@@ -28,6 +28,8 @@
 
 * (Для Linux 5.12 и ниже) Установите пакет, предоставляющий программу `fuse-overlayfs`.
 
+* (Для werf 3 и новее) Установите пакеты, предоставляющие бинарные файлы `netavark` и `pasta` (обычно это пакеты `netavark` и `passt`). werf ищет `netavark` только в каталогах вспомогательных бинарных файлов Podman (например, `/usr/lib/podman` или `/usr/libexec/podman`); дистрибутивные пакеты устанавливают его туда. Если в вашем дистрибутиве нет пакета netavark, поместите [бинарный файл из релиза](https://github.com/containers/netavark/releases) в `/usr/local/lib/podman/`.
+
 * Убедитесь, что путь `/home/<текущий пользователь>/.local/share/containers` создан, и текущий пользователь имеет доступ на чтение и запись.
 
 * Команда `sysctl -ne kernel.unprivileged_userns_clone` НЕ должна вернуть `0`, а иначе выполните `echo 'kernel.unprivileged_userns_clone = 1' | sudo tee -a /etc/sysctl.conf && sudo sysctl -p`.

--- a/bin/configurator/static/_includes/ru/configurator/tab/ci/other-ci-cd-system/simple/host-runner/linux/buildah/infra.md.liquid
+++ b/bin/configurator/static/_includes/ru/configurator/tab/ci/other-ci-cd-system/simple/host-runner/linux/buildah/infra.md.liquid
@@ -42,6 +42,8 @@
 
 * (Для Linux 5.12 и ниже) Установите пакет, предоставляющий программу `fuse-overlayfs`.
 
+* (Для werf 3 и новее) Установите пакеты, предоставляющие бинарные файлы `netavark` и `pasta` (обычно это пакеты `netavark` и `passt`). werf ищет `netavark` только в каталогах вспомогательных бинарных файлов Podman (например, `/usr/lib/podman` или `/usr/libexec/podman`); дистрибутивные пакеты устанавливают его туда. Если в вашем дистрибутиве нет пакета netavark, поместите [бинарный файл из релиза](https://github.com/containers/netavark/releases) в `/usr/local/lib/podman/`.
+
 * Убедитесь, что путь `/home/<пользователь для запуска CI-задач>/.local/share/containers` создан, и пользователь, из под которого запускаются CI-задачи, имеет доступ на чтение и запись.
 
 * Команда `sysctl -ne kernel.unprivileged_userns_clone` НЕ должна вернуть `0`, а иначе выполните `echo 'kernel.unprivileged_userns_clone = 1' | sudo tee -a /etc/sysctl.conf && sudo sysctl -p`.

--- a/install.sh
+++ b/install.sh
@@ -653,7 +653,23 @@ setup_buildah() {
   fi
 
   is_command_exists buildah || install_buildah "$user"
-    
+
+  local netavark_found="no"
+  local netavark_dir
+  for netavark_dir in /usr/local/libexec/podman /usr/local/lib/podman /usr/libexec/podman /usr/lib/podman; do
+    if [[ -x "$netavark_dir/netavark" ]]; then
+      netavark_found="yes"
+      break
+    fi
+  done
+  if [[ $netavark_found == "no" ]]; then
+    install_package "netavark" ||
+      log::warn "Failed to install netavark. werf 3 and later requires the netavark binary in a Podman helper binaries directory (e.g. /usr/lib/podman). Place a release binary from https://github.com/containers/netavark/releases in /usr/local/lib/podman/ manually."
+  fi
+
+  is_command_exists pasta || install_package "passt" ||
+    log::warn "Failed to install passt. werf 3 and later requires the pasta binary for rootless mode."
+
   if is_command_exists sysctl; then
   # Check if kernel.unprivileged_userns_clone exists
     if ! [ -z "$(sysctl -ne kernel.unprivileged_userns_clone)" ]; then


### PR DESCRIPTION
## Summary

Buildah host preparation for werf 3 now tells the reader to install `netavark` and `pasta`: without
netavark werf 3 fails at Buildah backend initialization, and without pasta a rootless `RUN` that
configures a network fails (werf/werf#7730).

## What

- The Buildah host preparation instructions gain one werf-3-scoped bullet, in EN and RU, in the same
  6 configurator sources as #769: `netavark` has to sit in a Podman helper binaries directory because
  `$PATH` is not searched, with a release-binary fallback for distributions that have no package, and
  a rootless build that configures a network also needs `pasta` from `passt`.
- `install.sh --setup-buildah` installs `netavark` — skipped when a helper directory already has the
  binary — and `passt`, and warns instead of failing where the packages do not exist. VERIFIED: the
  distribution packages do land netavark in a default helper directory (Ubuntu 24.04 →
  `/usr/lib/podman`; Fedora, CentOS Stream and Alpine → `/usr/libexec/podman`).
- UNVERIFIED: the warning path itself, on a distribution that packages neither binary (Ubuntu 22.04);
  a run of `install.sh --setup-buildah` there would settle it.
- Both installs run for every `--version`, not only for 3: the documented command hardcodes
  `--version 2`, so a werf-3 gate would stop them installing at all. A werf 2 user gets two extra
  packages, and two warnings on a distribution without them.

## Why

Nothing in Getting Started mentions either binary, so a host prepared from the current instructions
fails werf 3 at backend initialization — with an error naming a Podman directory that the reader has
no reason to connect to werf.
