### PR TITLE
chore(docs): register v3 as supported docs root

### DIFF
--- a/.helm/values.yaml
+++ b/.helm/values.yaml
@@ -47,6 +47,7 @@ resources:
 docs:
   currentRoot: v2
   supportedRoots:
+    - v3
     - v2
     - v1.2
   latestAliasEnabled: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
     image: $WERF_BACKEND_DOCKER_IMAGE_NAME
     environment:
       CURRENT_DOCS_MAJOR: "v2"
-      SUPPORTED_DOCS_MAJOR_VERSIONS: "v2,v1.2"
+      SUPPORTED_DOCS_MAJOR_VERSIONS: "v3,v2,v1.2"
       DOCS_LATEST_ALIAS_ENABLED: "true"
       LOG_LEVEL: info
       URL_VALIDATION: "false"


### PR DESCRIPTION
## Summary

Add `v3` to the supported docs major versions so the site router treats `/docs/v3` as addressable and the version switcher lists it. The default docs root stays `v2`.

## What

- `/docs/v3` (and `/docs/v3.*`) is an addressable docs root, and the version switcher now offers v3.
- `SUPPORTED_DOCS_MAJOR_VERSIONS` is `v3,v2,v1.2` for the backend (Helm production/test and the docker-compose dev env).
- Bare `/docs/` still redirects to `/docs/v2/`; `CURRENT_DOCS_MAJOR` is unchanged at `v2`.
- Does NOT change the default docs root.

## Why

The v3 documentation is being deployed from werf/werf's `3` branch, but the router and version menu are driven by `SUPPORTED_DOCS_MAJOR_VERSIONS`/`CURRENT_DOCS_MAJOR`; without v3 in the supported list the frontend would redirect `/docs/v3` to the default and omit it from the switcher. The backend already resolves arbitrary roots generically, so only the supported-roots value changes. The default stays v2 until v3 is promoted to current.
